### PR TITLE
update default url param and model

### DIFF
--- a/exp-models/addon/adapters/experiment.js
+++ b/exp-models/addon/adapters/experiment.js
@@ -2,4 +2,5 @@ import ApplicationAdapter from './application';
 import JamDocumentAdapter from '../mixins/jam-document-adapter';
 
 export default ApplicationAdapter.extend(JamDocumentAdapter, {
+	queryUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/documents',
 });

--- a/exp-models/addon/models/experiment.js
+++ b/exp-models/addon/models/experiment.js
@@ -7,10 +7,13 @@ import JamModel from '../mixins/jam-model';
 
 export default DS.Model.extend(JamModel, {
     title: DS.attr('string'),
-    description: DS.attr('string'),
-    active: DS.attr('boolean'),
-    structure: DS.attr(),
-    permissions: DS.attr(),
+	description: DS.attr('string'),
+	active: DS.attr('string'),
+	beginDate: DS.attr('date'),	// TODO: ISODate
+	endDate: DS.attr('date'),	// TODO: ISODate
+	lastEdited: DS.attr('date'),	// TODO: ISODate
+	structure: DS.attr(),
+	permissions: DS.attr(),
 
     administrators: DS.hasMany('admin'),
     history: DS.hasMany('history'),

--- a/exp-models/addon/models/experiment.js
+++ b/exp-models/addon/models/experiment.js
@@ -7,13 +7,13 @@ import JamModel from '../mixins/jam-model';
 
 export default DS.Model.extend(JamModel, {
     title: DS.attr('string'),
-	description: DS.attr('string'),
-	active: DS.attr('string'),
-	beginDate: DS.attr('date'),	// TODO: ISODate
-	endDate: DS.attr('date'),	// TODO: ISODate
-	lastEdited: DS.attr('date'),	// TODO: ISODate
-	structure: DS.attr(),
-	permissions: DS.attr(),
+    description: DS.attr('string'),
+    active: DS.attr('string'),
+    beginDate: DS.attr('date'),	// TODO: ISODate
+    endDate: DS.attr('date'),	// TODO: ISODate
+    lastEdited: DS.attr('date'),	// TODO: ISODate
+    structure: DS.attr(),
+    permissions: DS.attr(),
 
     administrators: DS.hasMany('admin'),
     history: DS.hasMany('history'),


### PR DESCRIPTION
# Changes
- update the default query url for the experiment page so that it is not using elastic search
- add necessary fields to experiment model
  - active (possibly change to status?) can be 'Active', 'Draft', or 'Archive'
# Question
- is date the proper type for `endDate`, `beginDate`, and `lastEdited`