### PR TITLE
Fix issues with session record

### DIFF
--- a/exp-models/addon/adapters/experiment.js
+++ b/exp-models/addon/adapters/experiment.js
@@ -2,5 +2,4 @@ import ApplicationAdapter from './application';
 import JamDocumentAdapter from '../mixins/jam-document-adapter';
 
 export default ApplicationAdapter.extend(JamDocumentAdapter, {
-	queryUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/documents',
 });

--- a/exp-models/addon/mixins/jam-document-adapter.js
+++ b/exp-models/addon/mixins/jam-document-adapter.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Mixin.create({
     findRecordUrlTemplate: '{+host}/{+namespace}/documents{/id}',
     findAllUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/documents',
-    queryUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/_search',
+    queryUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/documents',
 
     // TODO: Support creation and deletion of records
 

--- a/exp-models/addon/mixins/jam-serializer.js
+++ b/exp-models/addon/mixins/jam-serializer.js
@@ -17,6 +17,16 @@ export default Ember.Mixin.create({
         return this.modelName || this._super(key);
     },
 
+    extractAttributes: function(modelClass, resourceHash) {
+        // Keep track of the original ID values (string) alongside any relationships;
+        //  may help avoid a second API call when we want to display IDs of related records
+        var attributes = this._super(...arguments);
+        for (var item of this.relationAttrs) {
+            attributes[item + 'Id'] = resourceHash.attributes[item];
+        }
+        return attributes;
+    },
+
     extractRelationships: function(modelClass, resourceHash) {
         var relationships = this._super(...arguments);
         // Some relationships are stored as ID list under attributes; convert to JSONAPI format

--- a/exp-models/addon/models/profile.js
+++ b/exp-models/addon/models/profile.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 
 import JamModel from '../mixins/jam-model';
@@ -10,7 +11,6 @@ export default DS.Model.extend(JamModel, {
 
     account: DS.belongsTo('account'),
     history: DS.hasMany('history'),
-    sessions: DS.hasMany('session'),
 
     fullName: Ember.computed('firstName', 'lastName', function() {
         return `${this.get('firstName')} ${this.get('lastName')}`;

--- a/exp-models/addon/models/session.js
+++ b/exp-models/addon/models/session.js
@@ -6,10 +6,10 @@ import DS from 'ember-data';
 import JamModel from '../mixins/jam-model';
 
 export default DS.Model.extend(JamModel, {
-    softwareVersion: DS.Store('string'),
-    parameters: DS.Store(), // TODO: Nested document
-    data: DS.Store(),  // TODO: Nested document
-    timestamp: DS.Store('date'),  // Should we instead rely on Jam meta fields as stamp?
+    softwareVersion: DS.attr('string'),
+    parameters: DS.attr(),
+    expData: DS.attr(),  // Data is a reserved keyword in ember
+    timestamp: DS.attr('date'),  // Should we instead rely on Jam meta fields as stamp?
     permissions: DS.attr(),
 
     history: DS.hasMany('history'),
@@ -17,5 +17,5 @@ export default DS.Model.extend(JamModel, {
     profileID: DS.belongsTo('account'),
     //profileVersion: DS.Store('string'),  // TODO: safe to always assume newest profile version?
     experiment: DS.hasMany('experiment'),
-    experimentVersion: DS.Store('string'),
+    experimentVersion: DS.attr('string'),
 });

--- a/exp-models/addon/models/session.js
+++ b/exp-models/addon/models/session.js
@@ -16,11 +16,10 @@ export default DS.Model.extend(JamModel, {
 
     // JamDB requires two pieces of info to unambiguously identify a record
     profile: DS.belongsTo('profile'),
+    profileId: DS.attr('string'), // Store ID of related record
     profileVersion: DS.attr('string'),  // TODO: safe to always assume newest profile version?
 
     experiment: DS.belongsTo('experiment'),
+    experimentId: DS.attr('string'),
     experimentVersion: DS.attr('string'),
-
-
-    // TODO: Can we add computed properties for experiment name/ ID from a relationship?
 });

--- a/exp-models/addon/models/session.js
+++ b/exp-models/addon/models/session.js
@@ -6,16 +6,21 @@ import DS from 'ember-data';
 import JamModel from '../mixins/jam-model';
 
 export default DS.Model.extend(JamModel, {
-    softwareVersion: DS.attr('string'),
     parameters: DS.attr(),
+    softwareVersion: DS.attr('string'),
     expData: DS.attr(),  // Data is a reserved keyword in ember
     timestamp: DS.attr('date'),  // Should we instead rely on Jam meta fields as stamp?
     permissions: DS.attr(),
 
     history: DS.hasMany('history'),
+
     // JamDB requires two pieces of info to unambiguously identify a record
-    profileID: DS.belongsTo('account'),
-    //profileVersion: DS.Store('string'),  // TODO: safe to always assume newest profile version?
-    experiment: DS.hasMany('experiment'),
+    profile: DS.belongsTo('profile'),
+    profileVersion: DS.attr('string'),  // TODO: safe to always assume newest profile version?
+
+    experiment: DS.belongsTo('experiment'),
     experimentVersion: DS.attr('string'),
+
+
+    // TODO: Can we add computed properties for experiment name/ ID from a relationship?
 });

--- a/exp-models/addon/serializers/session.js
+++ b/exp-models/addon/serializers/session.js
@@ -4,5 +4,6 @@ import JamSerializer from '../mixins/jam-serializer';
 import JamDocumentSerializer from '../mixins/jam-document-serializer';
 
 export default DS.JSONAPISerializer.extend(JamSerializer, JamDocumentSerializer, {
-    modelName: 'session'
+    modelName: 'session',
+    relationAttrs: ['profile', 'experiment']
 });


### PR DESCRIPTION
Intended as companion to https://github.com/CenterForOpenScience/experimenter/pull/17

Refs https://openscience.atlassian.net/browse/LEI-42

## Purpose
Various changes to session model, needed to support related PR.

## Summary of changes
- DS.store should be DS.attr (fixes issue causing ember inspector to crash)
- Field name and relationship changes
- Apply query fix to all document records
- Add ability to track a text "<relationAttr>Id" field to a record, for any constructed records. Should save an API call when we want title of a related record.