### PR TITLE
Move initializer into exp-models

### DIFF
--- a/exp-models/app/instance-initializers/exp-models.js
+++ b/exp-models/app/instance-initializers/exp-models.js
@@ -1,0 +1,10 @@
+export function initialize(appInstance) {
+    // Make application instance available globally to allow dynamic registration of new models.
+    //  Refs http://emberigniter.com/accessing-global-object-in-ember-cli-app/  ; TODO: Is there a better way?
+    window.App = appInstance;
+}
+
+export default {
+    name: 'exp-models',
+    initialize: initialize
+};


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/LEI-78

Companion to https://github.com/CenterForOpenScience/experimenter/pull/31

## Purpose
Move "gloval app reference" into instance initializer for addon (rather than in the consuming app, eg "experimenter")., Then all apps using models will be able to register new models dynamically,without needing to add boilerplate.
https://github.com/CenterForOpenScience/experimenter/pull/31#discussion_r53316677