### PR TITLE
Add eligibility helpers

### DIFF
--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -2,6 +2,9 @@
 Manage data about one or more documents in the accounts collection
  */
 
+import moment from 'moment';
+
+import Ember from 'ember';
 import DS from 'ember-data';
 import JamModel from '../mixins/jam-model';
 
@@ -20,6 +23,15 @@ export default DS.Model.extend(JamModel, {
         var getProfile = function(item) {
             return item.profileId === profileId;
         };
-        return profiles.filter(getProfile)[0];
+
+        var Profile = Ember.Object.extend({
+            age: Ember.computed('birthday', function() {
+                var bd = moment(this.get('birthday'));
+                return moment(new Date()).diff(bd, 'days');
+            })
+        });
+        return Profile.create(
+            profiles.filter(getProfile)[0]
+        );
     }
 });

--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -9,6 +9,7 @@ import DS from 'ember-data';
 import JamModel from '../mixins/jam-model';
 
 var Profile = Ember.Object.extend({
+    birthday: null,
     age: Ember.computed('birthday', function() {
         var bd = moment(this.get('birthday'));
         return moment(new Date()).diff(bd, 'days');
@@ -26,7 +27,6 @@ export default DS.Model.extend(JamModel, {
             });
         },
         set: function(value) {
-            debugger;
             this.set('_profiles', value);
         }
     }),
@@ -38,11 +38,9 @@ export default DS.Model.extend(JamModel, {
         // Scan the list of profiles and gets first one with matching ID (else undefined). Assumes profileIds are unique.
         var profiles = this.get('profiles') || [];
         var getProfile = function(item) {
-            return item.profileId === profileId;
+            return item.get('profileId') === profileId;
         };
 
-        return Profile.create(
-            profiles.filter(getProfile)[0]
-        );
+        return profiles.filter(getProfile)[0];
     }
 });

--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -8,11 +8,28 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import JamModel from '../mixins/jam-model';
 
+var Profile = Ember.Object.extend({
+    age: Ember.computed('birthday', function() {
+        var bd = moment(this.get('birthday'));
+        return moment(new Date()).diff(bd, 'days');
+    })
+});
+
 export default DS.Model.extend(JamModel, {
     username: DS.attr('string'),
     password: DS.attr('string'),
-    profiles: DS.attr(),  // TODO: Pages using profiles will be fragile unless there is a clear, explicit contract of what fields ember can always expect to be present. This nested document doesn't inherently specify as such.
-
+    _profiles: DS.attr(), // TODO: Pages using profiles will be fragile unless there is a clear, explicit contract of what fields ember can always expect to be present. This nested document doesn't inherently specify as such.
+    profiles: Ember.computed('_profiles', {
+        get: function() {
+            return (this.get('_profiles') || []).map((p) => {
+                return Profile.create(p);
+            });
+        },
+        set: function(value) {
+            debugger;
+            this.set('_profiles', value);
+        }
+    }),
     permissions: DS.attr(),
 
     history: DS.hasMany('history'),
@@ -24,12 +41,6 @@ export default DS.Model.extend(JamModel, {
             return item.profileId === profileId;
         };
 
-        var Profile = Ember.Object.extend({
-            age: Ember.computed('birthday', function() {
-                var bd = moment(this.get('birthday'));
-                return moment(new Date()).diff(bd, 'days');
-            })
-        });
         return Profile.create(
             profiles.filter(getProfile)[0]
         );

--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -2,34 +2,15 @@
 Manage data about one or more documents in the accounts collection
  */
 
-import moment from 'moment';
-
-import Ember from 'ember';
 import DS from 'ember-data';
+
 import JamModel from '../mixins/jam-model';
 
-var Profile = Ember.Object.extend({
-    birthday: null,
-    age: Ember.computed('birthday', function() {
-        var bd = moment(this.get('birthday'));
-        return moment(new Date()).diff(bd, 'days');
-    })
-});
 
 export default DS.Model.extend(JamModel, {
     username: DS.attr('string'),
     password: DS.attr('string'),
-    _profiles: DS.attr(), // TODO: Pages using profiles will be fragile unless there is a clear, explicit contract of what fields ember can always expect to be present. This nested document doesn't inherently specify as such.
-    profiles: Ember.computed('_profiles', {
-        get: function() {
-            return (this.get('_profiles') || []).map((p) => {
-                return Profile.create(p);
-            });
-        },
-        set: function(value) {
-            this.set('_profiles', value);
-        }
-    }),
+    profiles: DS.attr('profiles'),
     permissions: DS.attr(),
 
     history: DS.hasMany('history'),

--- a/exp-models/addon/models/experiment.js
+++ b/exp-models/addon/models/experiment.js
@@ -20,9 +20,9 @@ export default DS.Model.extend(JamModel, {
 
     title: DS.attr('string'),
     description: DS.attr('string'),
-    beginDate: DS.attr('date'), // TODO: ISODate
-    endDate: DS.attr('date'), // TODO: ISODate
-    lastEdited: DS.attr('date'), // TODO: ISODate
+    beginDate: DS.attr('date'),
+    endDate: DS.attr('date'),
+    lastEdited: DS.attr('date'),
     structure: DS.attr(),
 
     permissions: DS.attr(),

--- a/exp-models/addon/models/experiment.js
+++ b/exp-models/addon/models/experiment.js
@@ -10,7 +10,7 @@ import SessionAdapter from '../adapters/session';
 import SessionModel from '../models/session';
 import SessionSerializer from '../serializers/session';
 
-import {compile} from '../utils/eligibility';
+import compile from '../utils/eligibility';
 
 export default DS.Model.extend(JamModel, {
     ACTIVE: 'Active',

--- a/exp-models/addon/models/experiment.js
+++ b/exp-models/addon/models/experiment.js
@@ -10,6 +10,7 @@ import SessionAdapter from '../adapters/session';
 import SessionModel from '../models/session';
 import SessionSerializer from '../serializers/session';
 
+import {compile} from '../utils/eligibility';
 
 export default DS.Model.extend(JamModel, {
     ACTIVE: 'Active',
@@ -19,9 +20,9 @@ export default DS.Model.extend(JamModel, {
 
     title: DS.attr('string'),
     description: DS.attr('string'),
-    beginDate: DS.attr('date'),	// TODO: ISODate
-    endDate: DS.attr('date'),	// TODO: ISODate
-    lastEdited: DS.attr('date'),	// TODO: ISODate
+    beginDate: DS.attr('date'), // TODO: ISODate
+    endDate: DS.attr('date'), // TODO: ISODate
+    lastEdited: DS.attr('date'), // TODO: ISODate
     structure: DS.attr(),
 
     permissions: DS.attr(),
@@ -37,6 +38,12 @@ export default DS.Model.extend(JamModel, {
         // TODO
         return eligibility || "None";
     }),
+    _isEligible: Ember.computed('eligibilityCriteria', function() {
+        return compile(this.get('eligibilityCriteria'));
+    }),
+    isEligible(participant) {
+        return this.get('_isEligible')(participant);
+    },
 
     history: DS.hasMany('history'),
 
@@ -58,5 +65,5 @@ export default DS.Model.extend(JamModel, {
         // When an experiment is loaded into the store, generate session-specific models
         this._super(...arguments);
         this._registerSessionModels();
-    },
+    }
 });

--- a/exp-models/addon/serializers/account.js
+++ b/exp-models/addon/serializers/account.js
@@ -17,5 +17,10 @@ export default DS.JSONAPISerializer.extend(JamSerializer, JamDocumentSerializer,
       }
 
       return this._super(record, options);
+    },
+    normalize: function(modelClass, data) {
+        data.attributes._profiles = data.attributes.profiles;
+        delete data.attributes.profiles;
+        return this._super(modelClass, data);
     }
 });

--- a/exp-models/addon/serializers/account.js
+++ b/exp-models/addon/serializers/account.js
@@ -8,9 +8,6 @@ let bcrypt = dcodeIO.bcrypt;
 export default DS.JSONAPISerializer.extend(JamSerializer, JamDocumentSerializer, {
     modelName: 'account',
     serialize(record, options) {
-        record.profiles = record._profiles;
-        delete record._profiles;
-
         if (record.record.get('isNew')) {
             record = record.record;
             var salt = bcrypt.genSaltSync(12);
@@ -19,10 +16,5 @@ export default DS.JSONAPISerializer.extend(JamSerializer, JamDocumentSerializer,
         }
 
         return this._super(record, options);
-    },
-    normalize: function(modelClass, data) {
-        data.attributes._profiles = data.attributes.profiles;
-        delete data.attributes.profiles;
-        return this._super(modelClass, data);
     }
 });

--- a/exp-models/addon/serializers/account.js
+++ b/exp-models/addon/serializers/account.js
@@ -7,16 +7,18 @@ let bcrypt = dcodeIO.bcrypt;
 
 export default DS.JSONAPISerializer.extend(JamSerializer, JamDocumentSerializer, {
     modelName: 'account',
-
     serialize(record, options) {
-      if(record.record.get('isNew')) {
-        record = record.record;
-        var salt = bcrypt.genSaltSync(12);
-        record.set('password', bcrypt.hashSync(record.get('password'), salt));
-        record = record._createSnapshot();
-      }
+        record.profiles = record._profiles;
+        delete record._profiles;
 
-      return this._super(record, options);
+        if (record.record.get('isNew')) {
+            record = record.record;
+            var salt = bcrypt.genSaltSync(12);
+            record.set('password', bcrypt.hashSync(record.get('password'), salt));
+            record = record._createSnapshot();
+        }
+
+        return this._super(record, options);
     },
     normalize: function(modelClass, data) {
         data.attributes._profiles = data.attributes.profiles;

--- a/exp-models/addon/transforms/profiles.js
+++ b/exp-models/addon/transforms/profiles.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+import moment from 'moment';
+
+var Profile = Ember.Object.extend({
+    profileId: null,
+    firstName: null,
+    birthday: null,
+    age: Ember.computed('birthday', function() {
+        var bd = moment(this.get('birthday'));
+        return moment(new Date()).diff(bd, 'days');
+    })
+});
+var profileProperties = ['birthday', 'firstName', 'profileId'];
+
+
+export default DS.Transform.extend({
+    deserialize(serialized) {
+        return serialized.map((profile) => {
+            if (profile.get) {
+                return profile;
+            }
+            else {
+                return Profile.create(profile);
+            }
+        });
+    },
+    serialize(deserialized) {
+        var ret = {};
+        profileProperties.forEach((prop) => ret[prop] = deserialized.get(prop));
+        return ret;
+    }
+});

--- a/exp-models/addon/utils/eligibility.js
+++ b/exp-models/addon/utils/eligibility.js
@@ -20,8 +20,8 @@ var OR = (a, b) => {
  * @return {integer}: number of days represented by amount/unit pair, e.g. 3 'weeks' -> 21
  **/
 function parseDate(amount, unit='days') {
-    var singular = unit.replace(/s$/, '');
-    return moment.duration(parseFloat(amount), `${singular}s`).asDays();
+    var inflector = new Ember.Inflector();
+    return moment.duration(parseFloat(amount), inflector.pluralize(unit)).asDays();
 }
 
 /** Compile an eligibiliy string into a function: (participant) -> boolean

--- a/exp-models/addon/utils/eligibility.js
+++ b/exp-models/addon/utils/eligibility.js
@@ -24,6 +24,22 @@ function parseDate(amount, unit='days') {
     return moment.duration(parseFloat(amount), `${singular}s`).asDays();
 }
 
+/** Compile an eligibiliy string into a function: (participant) -> boolean
+ *
+ * @param {string} elig: an eligibiliy string
+ * @returns {function (participant) -> boolean}
+ *
+ * Eligibilty strings should follow the general pattern: <attribute> <comparator> <value>
+ * These clauses can be joined with 'and' or 'or', and order of operations can be defined
+ * by wrapping a clause in '(' and ')'. <attribute>s must be attributes or computed values
+ * defined on the Profile class (e.g. 'age'). <comparator>s must be one of: '>', '>=', '<',
+ * '<=', 'is'. <value>s will be compared as numbers if $.isNumeric returns true when tested
+ * on that value.
+ *
+ * For the time being, 'age' is a special case that supports units of time. These units
+ * correspond directly with the units supported by the moment.duration constructor. This
+ * allows syntax like: 'age > 3 months' and also 'age < 5 years'.
+ **/
 function compileEligibilityString(elig) {
     var parts = elig.split(/(\(|\)|and|or)/).map((p) => p.trim()).filter((p) => p.length);
     var part = parts.shift();

--- a/exp-models/addon/utils/eligibility.js
+++ b/exp-models/addon/utils/eligibility.js
@@ -1,0 +1,108 @@
+// h/t @aaxelb
+
+var AND = (a, b) => {
+    return function() {
+        return a(...arguments) && b(...arguments);
+    };
+};
+var OR = (a, b) => {
+    return function() {
+        return a(...arguments) || b(...arguments);
+    };
+};
+
+function parseDate(amount, unit) {
+    if (/days?/i.test(unit)) {
+        return amount;
+    }
+    else if (/weeks?/i.test(unit)) {
+        return amount * 7;
+    }
+    else if (/months?/i.test(unit)) {
+        return amount * 29.5; // approximately one lunar month
+    }
+    else { // years
+        return amount * 365;
+    }
+}
+
+function compileEligibilityString(elig) {
+    var parts = elig.split(/(\(|\)|and|or)/).map((p) => p.trim()).filter((p) => p.length);
+    var part = parts.shift();
+
+    var isEligible;
+    if (part === '(') {
+        var depth = 1;
+        var acc = [];
+        while (true) {
+            var next = parts.shift();
+            if (next === ')') {
+                depth--;
+                if (!depth) {
+                    break;
+                }
+            } else if (next === '(') {
+                depth++;
+            }
+            acc.push(next);
+        }
+        isEligible = compileEligibilityString(acc.join(' '));
+    } else {
+        var terms = part.split(/(>|<|>=|<=|is)/).map((p) => p.trim());
+        var prop = terms.shift();
+        var op = terms.shift();
+        var [value, unit] = terms.shift();
+
+        var opFn;
+        if (op === '>') {
+            opFn = function gt(a, b) {
+                return parseFloat(a) > parseFloat(b);
+            };
+        }
+        if (op === '>=') {
+            opFn = function gte(a, b) {
+                return parseFloat(a) >= parseFloat(b);
+            };
+        }
+        if (op === '<') {
+            opFn = function lt(a, b) {
+                return parseFloat(a) < parseFloat(b);
+            };
+        }
+        if (op === '<=') {
+            opFn = function lte(a, b) {
+                return parseFloat(a) <= parseFloat(b);
+            };
+        }
+        if (op === 'is') {
+            opFn = function eq(a, b) {
+                return a === b;
+            };
+        }
+
+        isEligible = function(participant) {
+            // A slight hack
+            if (prop === 'age') {
+                value = parseDate(value, unit);
+            }
+
+            return opFn(participant.get(prop), value);
+        };
+
+    }
+    if (parts.length) {
+        var nextOp = parts.shift();
+        if (nextOp === 'and') {
+            return AND(isEligible, compileEligibilityString(parts.join(' ')));
+        } else if (nextOp === 'or') {
+            return OR(isEligible, compileEligibilityString(parts.join(' ')));
+        }
+    } else {
+        return isEligible;
+    }
+    return false;
+}
+
+export default {
+    compile: compileEligibilityString
+};

--- a/exp-models/app/transforms/profiles.js
+++ b/exp-models/app/transforms/profiles.js
@@ -1,0 +1,1 @@
+export { default } from 'exp-models/transforms/profiles';

--- a/exp-models/tests/unit/transforms/profiles-test.js
+++ b/exp-models/tests/unit/transforms/profiles-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('transform:profiles', 'Unit | Transform | profiles', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let transform = this.subject();
+  assert.ok(transform);
+});


### PR DESCRIPTION
Changes:

- Add eligibility.js utils for parsing and checking eligibility
- Make account.profiles computed to allow transformation into a genuine Ember.Object subclass
- Add 'age' computed to Profile class