### PR TITLE
Fix state and component transition issues

### DIFF
--- a/exp-player/addon/components/exp-audioplayer.js
+++ b/exp-player/addon/components/exp-audioplayer.js
@@ -43,18 +43,17 @@ export default ExpFrameBaseComponent.extend({
                     default: []
                 }
             }
-        }
-    },
-
-    data: {
-        type: 'object',
-        properties: {  // We don't *need* to tell the server about this, but it might be nice to track usage of the setup page
-            didFinishSound: {
-                type: 'boolean',
-                default: false
-            }
         },
-        required: ['didFinishSound']
+        data: {
+            type: 'object',
+            properties: {  // We don't *need* to tell the server about this, but it might be nice to track usage of the setup page
+                didFinishSound: {
+                    type: 'boolean',
+                    default: false
+                }
+            },
+            required: ['didFinishSound']
+        },
     },
 
     actions: {

--- a/exp-player/addon/components/exp-audioplayer.js
+++ b/exp-player/addon/components/exp-audioplayer.js
@@ -67,7 +67,7 @@ export default ExpFrameBaseComponent.extend({
         }
     },
 
-    preventNext: Ember.computed('didFinishSound', function() {
+    preventNext: Ember.computed('mustPlay', 'didFinishSound', function() {
         if (!this.get('mustPlay')) {
             return false;
         } else {

--- a/exp-player/addon/components/exp-consent.js
+++ b/exp-player/addon/components/exp-consent.js
@@ -4,7 +4,7 @@ import layout from '../templates/components/exp-consent';
 
 export default ExpFrameBaseComponent.extend({
     layout: layout,
-    meta: {  // Configuration for all fields available on the component/template
+    meta: {
         name: 'Consent Form',
         description: 'A simple consent form.',
         parameters: {
@@ -32,8 +32,7 @@ export default ExpFrameBaseComponent.extend({
                 }
             }
         },
-        data: {  // Control parameters that are tracked and serialized. Ideally should provide validation mechanism.
-            // TODO: The player should merge data fields as well as params- or ideally, add some scoping
+        data: {
             type: 'object',
             properties: {
                 consentGranted: {

--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -18,7 +18,12 @@ export default Ember.Component.extend({
         parameters: {},  // Configuration parameters, which can be auto-populated from the experiment structure JSON
         data: {},  // Controls what and how parameters are serialized and sent to the server
     },
-    eventTimings: [], // TODO: Simplify default values mechanism
+    init() {
+        // TODO: Add a mechanism for setting all params in data
+        this.set('eventTimings', []);
+        this._super(...arguments);
+    },
+
     setupParams(params) {
         params = params || this.get('params');
 

--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -16,7 +16,10 @@ export default Ember.Component.extend({
         name: 'Base Experimenter Frame',
         description: 'The abstract base frame for Experimenter frames.',
         parameters: {},  // Configuration parameters, which can be auto-populated from the experiment structure JSON
-        data: {},  // Controls what and how parameters are serialized and sent to the server
+        data: {
+            type: 'object',
+            properties: {}
+        },  // Controls what and how parameters are serialized and sent to the server
     },
 
     init: function() {
@@ -36,11 +39,16 @@ export default Ember.Component.extend({
     }.on('didReceiveAttrs'),
 
     setupParams(params) {
+        // Add config properties and data to be serialized as instance parameters (overriding with values explicitly passed in)
         params = params || this.get('params');
 
         var defaultParams = {};
         Object.keys(this.get('meta.parameters').properties || {}).forEach((key) => {
             defaultParams[key] = this.get(`meta.parameters.properties.${key}.default`);
+        });
+
+        Object.keys(this.get('meta.data').properties || {}).forEach((key) => {
+            defaultParams[key] = this.get(`meta.data.properties.${key}.default`);
         });
 
         Ember.merge(defaultParams, params);

--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -22,8 +22,7 @@ export default Ember.Component.extend({
         },  // Controls what and how parameters are serialized and sent to the server
     },
 
-    init: function() {
-        this._super(...arguments);
+    onInit: function() {
         this.set('eventTimings', []);
 
         var defaultParams = this.setupParams();

--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -12,17 +12,22 @@ export default Ember.Component.extend({
     id: null,
     type: null,
     ctx: null,
-    meta: {
+    meta: {  // Configuration for all fields available on the component/template
         name: 'Base Experimenter Frame',
         description: 'The abstract base frame for Experimenter frames.',
-        parameters: {},  // Configuration parameters, which can be auto-populated from the experiment structure JSON
-        data: {
+        parameters: {  // Configuration parameters, which can be auto-populated from the experiment structure JSON
             type: 'object',
             properties: {}
-        },  // Controls what and how parameters are serialized and sent to the server
+        },
+        data: {  // Controls what and how parameters are serialized and sent to the server. Ideally there should be a validation mechanism.
+            type: 'object',
+            properties: {}
+        },
     },
+    eventTimings: null,
 
-    onInit: function() {
+    init: function() {
+        this._super(...arguments);
         this.set('eventTimings', []);
 
         var defaultParams = this.setupParams();
@@ -35,7 +40,7 @@ export default Ember.Component.extend({
             var type = this.get('type');
             this.set('id', `${type}-${frameIndex}`);
         }
-    }.on('didReceiveAttrs'),
+    },
 
     setupParams(params) {
         // Add config properties and data to be serialized as instance parameters (overriding with values explicitly passed in)

--- a/exp-player/addon/components/exp-video.js
+++ b/exp-player/addon/components/exp-video.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
 import layout from '../templates/components/exp-video';
 
@@ -36,11 +35,10 @@ export default ExpFrameBaseComponent.extend({
                     default: []
                 }
             }
-        }
-    },
-
-    data: {
-        // This video does not explicitly capture any parameters from the user
+        },
+        data: {
+            // This video does not explicitly capture any parameters from the user
+        },
     },
 
     autoFullscreen: function() {


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/LEI-88
Tracking PR; see checklist for status.

## Purpose
Fix issues of shared and lingering state in the experimenter player.

- [x] Same timings data is replicated across all frames

- [x] Clicking the last consent frame: problem where button does not correctly activate until checked and unchecked several times

- [ ] When two video player frames are shown in a row, the second frame does not load the new video. It simply uses the video content from the first video frame. (even though the poster image loads correctly, it does not even attempt to download the video piece)
  - It appears that `willDestroyElement` is not called either. Speculatively, it seems that the *same* component is getting new parameters; rather than creating a second new instance of the same type.


## Summary of changes
- Make sure that init creates instance variables for  `meta.data` (things to be serialized), in addition to the vars already added for `meta.parameters` (things to control config of page)