### PR TITLE
Force media elements to reload

### DIFF
--- a/exp-player/addon/components/exp-audioplayer.js
+++ b/exp-player/addon/components/exp-audioplayer.js
@@ -1,8 +1,11 @@
 import Ember from 'ember';
-import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
 import layout from '../templates/components/exp-audioplayer';
 
-export default ExpFrameBaseComponent.extend({
+import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
+import MediaReload from '../mixins/media-reload';
+
+
+export default ExpFrameBaseComponent.extend(MediaReload, {
     layout: layout,
     didFinishSound: false,
     meta: {

--- a/exp-player/addon/components/exp-video.js
+++ b/exp-player/addon/components/exp-video.js
@@ -1,7 +1,10 @@
 import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
 import layout from '../templates/components/exp-video';
 
-export default ExpFrameBaseComponent.extend({
+import MediaReload from '../mixins/media-reload';
+
+
+export default ExpFrameBaseComponent.extend(MediaReload, {
     layout: layout,
     meta: {
         name: 'Video player',

--- a/exp-player/addon/mixins/media-reload.js
+++ b/exp-player/addon/mixins/media-reload.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+
+/*
+    Allow any media-containing component to correctly reset.
+    Fix LEI-93, an issue where the second of two consecutive videos did not play correctly.
+ */
+export default Ember.Mixin.create({
+    mediaTags: ['audio', 'video'],
+
+    didRender() {
+        this._super(...arguments);
+        for (var selector of this.get('mediaTags')) {
+            $(selector).each(function(){
+                this.pause();
+                this.load()
+            })
+        }
+    }
+});

--- a/exp-player/tests/unit/mixins/media-reload-test.js
+++ b/exp-player/tests/unit/mixins/media-reload-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import MediaReloadMixin from '../../../mixins/media-reload';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | media reload');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let MediaReloadObject = Ember.Object.extend(MediaReloadMixin);
+  let subject = MediaReloadObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
Refs [#LEI-93]

## Purpose
Fixes an issue where when two video or sound frames appeared in a row, the media clip from the second frame would not display correctly.

(Eg, the second frame would show the video from frame 1, and the time bar would be at the end, not the start)

All components that use media will need to extend with this mixin.