### PR TITLE
Add mixin classes for notifiying a user when they try to leave a stud…

### DIFF
--- a/exp-player/addon/mixins/warn-on-exit-route.js
+++ b/exp-player/addon/mixins/warn-on-exit-route.js
@@ -6,7 +6,7 @@ export default Ember.Mixin.create({
             if(confirmed) {
                 controller.set('forceExit', true);
                 var session = this.get('controller.session');
-                session.set('didComplete', false);
+                session.set('complete', false);
                 session.set('earlyExit', data);
                 session.save();
                 transition.retry();

--- a/exp-player/addon/templates/components/exit-warning.hbs
+++ b/exp-player/addon/templates/components/exit-warning.hbs
@@ -22,7 +22,7 @@
         </p>
         <div class="form-group">
           <div class="checkbox">
-            {{radio-button value="publicity and educatonal" checked=exitPrivacy}} Publicity and educational (video may be used for publicity or educa-onal purposes online or in the press in additon to for research purposes)
+            {{radio-button value="publicity and educatonal" checked=exitPrivacy}} Publicity and educational (video may be used for publicity or educational purposes online or in the press in additon to for research purposes)
           </div>
           <div class="checkbox">
             {{radio-button value="scientific" checked=exitPrivacy}} Scientific use only (e.g., a short clip may be shown at a scientific conference to demonstrate typical responses)


### PR DESCRIPTION
# Purpose

We need a way to warn users if they try to leave a study early that is generalizable to Experimenter and Lookit. Before we were checking the dirty state of the session and alerting the user if they tried to leave early. 

More realistically we want to alert the user no matter when they leave a study (for Lookit at least, a study is non-resumable). This implements this behavior as mixing classes and a component, and its use is demonstrated in https://github.com/CenterForOpenScience/experimenter/pull/70