### PR TITLE
A better way of fetching past sessions?

### DIFF
--- a/exp-models/addon/mixins/jam-document-adapter.js
+++ b/exp-models/addon/mixins/jam-document-adapter.js
@@ -3,7 +3,9 @@ import Ember from 'ember';
 export default Ember.Mixin.create({
     findRecordUrlTemplate: '{+host}/{+namespace}/documents{/id}',
     findAllUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/documents',
+
     queryUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}{/search}',
+    queryRecordUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}{/search}',
 
     createRecordUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/documents',
     // TODO: Support creation and deletion of records

--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -1,6 +1,7 @@
 /*
 Manage data about one or more documents in the accounts collection
  */
+import Ember from 'ember';
 import DS from 'ember-data';
 
 import JamModel from '../mixins/jam-model';
@@ -23,9 +24,10 @@ export default DS.Model.extend(JamModel, {
 
         return profiles.filter(getProfile)[0];
     },
-    pastSessionsFor(experiment) {
+    pastSessionsFor(experiment, profile) {
+        var profileId = Ember.get(profile, 'id') || '*';
         return this.get('store').queryRecord(experiment.get('sessionCollectionId'), {
-            q: `profileId:${this.get('id')}*`
+            q: `profileId:${this.get('id')}${profileId}`
         });
     }
 });

--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -1,7 +1,6 @@
 /*
 Manage data about one or more documents in the accounts collection
  */
-
 import DS from 'ember-data';
 
 import JamModel from '../mixins/jam-model';
@@ -23,5 +22,10 @@ export default DS.Model.extend(JamModel, {
         };
 
         return profiles.filter(getProfile)[0];
+    },
+    pastSessionsFor(experiment) {
+        return this.get('store').queryRecord(experiment.get('sessionCollectionId'), {
+            q: `profileId:${this.get('id')}*`
+        });
     }
 });

--- a/exp-models/addon/services/current-user.js
+++ b/exp-models/addon/services/current-user.js
@@ -1,0 +1,40 @@
+import Ember from 'ember';
+
+import config from 'ember-get-config';
+
+export default Ember.Service.extend({
+    store: Ember.inject.service(),
+    session: Ember.inject.service(),
+    account: null,
+
+    init() {
+        this._super(...arguments);
+
+        this.get('session').on('invalidationSucceeded', () => {
+            this.set('account', null);
+        });
+    },
+
+    getCurrentUser() {
+        return new Ember.RSVP.Promise((resolve, reject) => {
+            if(!this.get('session.isAuthenticated')) {
+                resolve(null);
+            }
+            else {
+                if (this.get('account')) {
+                    resolve(this.get('account'));
+                }
+
+                var data = this.get('session.data.authenticated');
+                var accountId = null;
+                if(data.provider === 'osf') {
+                    accountId = config.JAMDB.testAccount.id;
+                }
+                else if(data.provider === `${config.JAMDB.namespace}:accounts`) {
+                    accountId = data.id;
+                }
+                resolve(this.get('store').findRecord('account', `${config.JAMDB.namespace}.accounts.${accountId}`).catch(reject));
+            }
+        });
+    }
+});

--- a/exp-models/addon/services/current-user.js
+++ b/exp-models/addon/services/current-user.js
@@ -2,6 +2,11 @@ import Ember from 'ember';
 
 import config from 'ember-get-config';
 
+let ADMIN = {
+    id: 'ADMIN',
+    profileId: 'ADMIN.PROFILE'
+};
+
 export default Ember.Service.extend({
     store: Ember.inject.service(),
     session: Ember.inject.service(),
@@ -27,13 +32,22 @@ export default Ember.Service.extend({
 
                 var data = this.get('session.data.authenticated');
                 var accountId = null;
+                var profileId = null;
                 if(data.provider === 'osf') {
-                    accountId = config.JAMDB.testAccount.id;
+                    accountId = ADMIN.id;
+                    profileId = ADMIN.profileId;
                 }
                 else if(data.provider === `${config.JAMDB.namespace}:accounts`) {
                     accountId = data.id;
+                    profileId = this.get('data.profile.profileId');
                 }
-                resolve(this.get('store').findRecord('account', `${config.JAMDB.namespace}.accounts.${accountId}`).catch(reject));
+                resolve(
+                    this.get('store').findRecord('account', `${config.JAMDB.namespace}.accounts.${accountId}`)
+                        .then((account) => {
+                            return [account, account.profileById(profileId)];
+                        })
+                        .catch(reject)
+                );
             }
         });
     }

--- a/exp-models/app/services/current-user.js
+++ b/exp-models/app/services/current-user.js
@@ -1,0 +1,1 @@
+export { default } from 'exp-models/services/current-user';

--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -27,6 +27,7 @@ export default Ember.Component.extend({
 
     frameIndex: null,
     frameConfig: null,
+    frameContext: null,
     eventTimings: null,
 
     session: null,

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -44,6 +44,12 @@ export default Ember.Component.extend(FullScreen, {
         return componentName;
     }),
 
+    currentFrameContext: Ember.computed('pastSessions', function() {
+        return {
+            pastSessions: this.get('pastSessions')
+        };
+    }),
+
     actions: {
         saveFrame(frameId, frameData) {
             // Save the data from a completed frame to the session data item

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -56,6 +56,8 @@ export default Ember.Component.extend(FullScreen, {
             var expData = this.get('expData');
             expData[frameId] = frameData;
             this.set('expData', expData);
+            // TODO better incremental saving?
+            this.send('saveSession');
         },
         saveSession() {
             // Construct payload and send to server

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -11,6 +11,8 @@ export default Ember.Component.extend(FullScreen, {
     session: null,
     frames: null,
 
+    pastSessions: null,
+
     frameIndex: 0,  // Index of the currently active frame
 
     displayFullscreen: false,
@@ -20,6 +22,7 @@ export default Ember.Component.extend(FullScreen, {
 
     init: function() {
         this._super(...arguments);
+
         var frameConfigs = parseExperiment(this.get('experiment.structure'));
         this.set('frames', frameConfigs);  // When player loads, convert structure to list of frames
         this.set('displayFullscreen', this.get('experiment.displayFullscreen') || false);  // Choose whether to display this experiment fullscreen (default false)

--- a/exp-player/addon/mixins/exp-player-route.js
+++ b/exp-player/addon/mixins/exp-player-route.js
@@ -1,0 +1,43 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+    _experiment: null,
+    _session: null,
+
+    currentUser: Ember.inject.service(),
+
+    _getExperiment(params) { // jshint ignore: line
+
+    },
+    _getSession(params, experiment) { // jshint ignore: line
+
+    },
+    model(params) {
+        // While a little gross, this ensures all the criteria for participation
+        // are met before the route resolves. This has the benefit that the route's
+        // loading state is active until all of this is complete.
+        return this._getExperiment(params).then((experiment) => {
+            return this._getSession(params, experiment).then((session) => {
+
+                this.set('_experiment', experiment);
+                this.set('_session', session);
+
+                return experiment.getCurrentVersion().then(versionId => {
+                    session.set('experimentVersion', versionId);
+                    return session.save().then(() => {
+                        return this.get('currentUser').getCurrentUser((account) => {
+                            return account.pastSessionsFor(experiment);
+                        });
+                    });
+                });
+            });
+        });
+    },
+    setupController(controller, pastSessions) {
+        this._super(controller, pastSessions);
+
+        controller.set('experiment', this.get('_experiment'));
+        controller.set('session', this.get('_session'));
+        controller.set('pastSessions', pastSessions);
+    }
+});

--- a/exp-player/addon/mixins/exp-player-route.js
+++ b/exp-player/addon/mixins/exp-player-route.js
@@ -25,8 +25,8 @@ export default Ember.Mixin.create({
                 return experiment.getCurrentVersion().then(versionId => {
                     session.set('experimentVersion', versionId);
                     return session.save().then(() => {
-                        return this.get('currentUser').getCurrentUser((account) => {
-                            return account.pastSessionsFor(experiment);
+                        return this.get('currentUser').getCurrentUser(([account, profile]) => {
+                            return account.pastSessionsFor(experiment, profile);
                         });
                     });
                 });

--- a/exp-player/addon/templates/components/exp-player.hbs
+++ b/exp-player/addon/templates/components/exp-player.hbs
@@ -3,6 +3,7 @@
     component currentFrameTemplate
     frameIndex=frameIndex
     frameConfig=currentFrameConfig
+    frameContext=currentFrameContext
 
     session=session
     saveHandler=(action 'saveFrame')

--- a/exp-player/tests/unit/mixins/exp-player-route-test.js
+++ b/exp-player/tests/unit/mixins/exp-player-route-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import ExpPlayerRouteMixin from '../../../mixins/exp-player-route';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | exp player route');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let ExpPlayerRouteObject = Ember.Object.extend(ExpPlayerRouteMixin);
+  let subject = ExpPlayerRouteObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
Use a route mixin to make the exp-player route load until all of the
needed data is ready and successfully saved. This allows us to leverage
the loading substate of that route to give better feedback to the user,
and give better confidence that once the player is loaded it has
everything it needs to run.