### PR TITLE
[Feature] move datepicker to bottom of field and remove duplicate page title

### DIFF
--- a/exp-player/addon/components/exp-exit-survey.js
+++ b/exp-player/addon/components/exp-exit-survey.js
@@ -7,8 +7,6 @@ import layout from '../templates/components/exp-exit-survey';
 
 const defaultSchema = {
     schema: {
-        title: "Post-study survey",
-        description: "How was your experience?",
         type: "object",
         properties: {
             birthdate: {

--- a/exp-player/addon/styles/components/exp-mood-questionnaire.scss
+++ b/exp-player/addon/styles/components/exp-mood-questionnaire.scss
@@ -31,6 +31,6 @@
 
     // position it on top of input
     .dropdown-menu {
-        top: -245px !important;
+        bottom: -245px !important;
     }
 }


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-140

## Purpose
Move the date picker so that it doesn't go off the top of the screen.
Remove duplicate page title.

## Summary of changes
Place the date picker below the field instead of above.
Remove title and description from form schema.

Previous:
![screen shot 2016-03-14 at 1 03 27 pm](https://cloud.githubusercontent.com/assets/7131985/13753304/cb7aa230-e9e8-11e5-993e-b502313f5add.png)
![screen shot 2016-03-14 at 1 03 36 pm](https://cloud.githubusercontent.com/assets/7131985/13753309/cdfbd222-e9e8-11e5-8c6b-1ab5afbb0db4.png)

Current:
![screen shot 2016-03-14 at 1 31 11 pm](https://cloud.githubusercontent.com/assets/7131985/13753368/0da4c596-e9e9-11e5-8201-840e601733ac.png)


## Testing notes
The date picker should be completely on the page.
