### PR TITLE
Support Lookit + revised URLs

### DIFF
--- a/exp-models/addon/services/current-user.js
+++ b/exp-models/addon/services/current-user.js
@@ -34,7 +34,7 @@ export default Ember.Service.extend({
                     ]);
                 }
                 else if(data.provider === `${config.JAMDB.namespace}:accounts`) {
-                    this.get('store').findRecord('account', `${config.JAMDB.namespace}.accounts.${data.id}`)
+                    this.get('store').findRecord('account', `${data.id}`)
                         .then((account) => {
                             resolve([account, account.profileById(this.get('session.data.profile.profileId'))]);
                         })

--- a/exp-player/addon/components/exp-exit-survey.js
+++ b/exp-player/addon/components/exp-exit-survey.js
@@ -146,7 +146,7 @@ export default ExpFrameBaseComponent.extend({
         }
     }),
     section1: true,
-    formData: {}, // Possible inconsistency with data.properties?
+    formData: {},
     formActions: Ember.computed(function() {
         var root = this;
         return {

--- a/exp-player/addon/components/exp-exit-survey.js
+++ b/exp-player/addon/components/exp-exit-survey.js
@@ -117,7 +117,8 @@ export default ExpFrameBaseComponent.extend({
             type: 'object',
             properties: {
                 formData: {
-                    type: 'object'
+                    type: 'object',
+                    default: {}
                 }
             }
         }
@@ -145,7 +146,7 @@ export default ExpFrameBaseComponent.extend({
         }
     }),
     section1: true,
-    formData: [],
+    formData: {}, // Possible inconsistency with data.properties?
     formActions: Ember.computed(function() {
         var root = this;
         return {
@@ -158,7 +159,9 @@ export default ExpFrameBaseComponent.extend({
             },
             finish: function() {
                 var formData = root.get('formData');
+                console.log('got here', formData);
                 Ember.merge(formData, this.getValue());
+                console.log('also got here', formData);
                 root.set('formData', formData);
                 console.log('Post-study survey complete.');
                 root.actions.next.apply(root);

--- a/exp-player/addon/components/exp-exit-survey.js
+++ b/exp-player/addon/components/exp-exit-survey.js
@@ -159,9 +159,7 @@ export default ExpFrameBaseComponent.extend({
             },
             finish: function() {
                 var formData = root.get('formData');
-                console.log('got here', formData);
                 Ember.merge(formData, this.getValue());
-                console.log('also got here', formData);
                 root.set('formData', formData);
                 console.log('Post-study survey complete.');
                 root.actions.next.apply(root);

--- a/exp-player/addon/components/exp-exit-survey.js
+++ b/exp-player/addon/components/exp-exit-survey.js
@@ -52,7 +52,7 @@ const emailOptOutSchema = {
         type: "object",
         properties: {
             emailOptOut: {
-                title: "You are currently signed up to recieve email reminders about this study."
+                title: "You are currently signed up to receive email reminders about this study."
             }
         }
     },

--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -65,10 +65,11 @@ export default Ember.Component.extend({
         });
 
         Object.keys(this.get('meta.data').properties || {}).forEach((key) => {
-            if (this[key] && this[key].isDescriptor) return;
+            if (this[key] && this[key].isDescriptor) {return;}
             var value = !clean ? this.get(key): undefined;
             if (typeof value === 'undefined') {
-                defaultParams[key] =  this.get(`meta.data.properties.${key}.default`);
+                // Make deep copy of the default value (to avoid subtle reference errors from reusing mutable containers)
+                defaultParams[key] =  Ember.copy(this.get(`meta.data.properties.${key}.default`), true);
             }
             else {
                 defaultParams[key] = value;


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-160
Companion to: https://github.com/CenterForOpenScience/lookit/pull/44

## Purpose
Fix small issues with lookit + newest codebase.

## Testing notes
This should fix adapter errors that occur when trying to participate in an experiment via lookit. (due to the current user service requesting `experimenter.accounts.experimenter.accounts.tester0` or such).

At the end of the experiment, you should now be able to opt out of emails, and have data submit to server. Previously, due to the lack of a default value, this resulted in errors of "Uncaught TypeError: Cannot set property 'emailOptOut' of undefined" being dumped to the console. (which prevented the value from being sent)