### PR TITLE
Fix broken frames

### DIFF
--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -31,19 +31,19 @@ export default Ember.Component.extend({
     eventTimings: null,
 
     session: null,
-    didReceiveAttrs: function(diff) {
+    didReceiveAttrs: function(options) {
         this._super(...arguments);
 
         if (!this.get('frameConfig')) {
             return;
         }
 
-        var newAttrs = diff.newAttrs || {};
-        var oldAtrs = diff.oldAtrs || {};
+        var newAttrs = options.newAttrs || {};
+        var oldAttrs = options.oldAttrs || {};
 
         this.set('eventTimings', []);
 
-        let clean = Ember.get(newAttrs, 'frameIndex.value') !== Ember.get(oldAtrs, 'frameIndex.value');
+        let clean = Ember.get(newAttrs, 'frameIndex.value') !== Ember.get(oldAttrs, 'frameIndex.value');
         var defaultParams = this.setupParams(null, clean);
         Object.keys(defaultParams).forEach((key) => {
             this.set(key, defaultParams[key]);

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -30,7 +30,7 @@ export default Ember.Component.extend(FullScreen, {
 
         var session = this.get('session');
         session.setProperties({
-            sequence: frameConfigs.map((cfg) => cfg.id),
+            sequence: [],  // Frame IDs will be appended by saveFrame action
             conditions: conditions
         });
         session.save();
@@ -81,6 +81,7 @@ export default Ember.Component.extend(FullScreen, {
                 this.set('frameIndex', frameIndex + 1);
                 return;
             }
+            // Hack: at last frame, save instead of advancing frame
             this.get('session').set('completed', true);
             console.log(`Next: Saving session then redirecting to ${this.get('experiment.exitUrl') || '/'}`);
             this.get('session').save().then(() => window.location = this.get('experiment.exitUrl') || '/');

--- a/exp-player/addon/templates/components/exp-player.hbs
+++ b/exp-player/addon/templates/components/exp-player.hbs
@@ -1,13 +1,9 @@
-<div class="row">
-    <div class="col-xs-12">
-        {{#if (and (not isFullscreen) experiment.displayFullscreen)}}
-            <button style="width: 100%" class="btn btn-warning" {{ action 'showFullscreen' }}>Return to fullscreen</button>
-        {{/if}}
-    </div>
-</div>
-
 <div class="row" id="experiment-player">
 <div class="col-xs-12">
+        {{#if (and (not isFullscreen) experiment.displayFullscreen)}}
+            <p><button style="width: 100%" class="btn btn-warning" {{ action 'showFullscreen' }}>Return to fullscreen</button></p>
+        {{/if}}
+
     {{
     component currentFrameTemplate
     frameIndex=frameIndex

--- a/exp-player/addon/templates/components/exp-player.hbs
+++ b/exp-player/addon/templates/components/exp-player.hbs
@@ -8,21 +8,19 @@
 
 <div class="row" id="experiment-player">
 <div class="col-xs-12">
-    <div id="component-here">
-        {{
-        component currentFrameTemplate
-        frameIndex=frameIndex
-        frameConfig=currentFrameConfig
-        frameContext=currentFrameContext
+    {{
+    component currentFrameTemplate
+    frameIndex=frameIndex
+    frameConfig=currentFrameConfig
+    frameContext=currentFrameContext
 
-        session=session
-        experiment=experiment
+    session=session
+    experiment=experiment
 
-        next=(action 'next')
-        previous=(action 'previous')
-        saveHandler=(action 'saveFrame')
-        }}
-    </div>
+    next=(action 'next')
+    previous=(action 'previous')
+    saveHandler=(action 'saveFrame')
+    }}
 </div>
 </div>
 

--- a/exp-player/addon/templates/components/exp-player.hbs
+++ b/exp-player/addon/templates/components/exp-player.hbs
@@ -1,21 +1,3 @@
-<div class="row" id="experiment-player">
-<div class="col-xs-12">
-    {{
-    component currentFrameTemplate
-    frameIndex=frameIndex
-    frameConfig=currentFrameConfig
-    frameContext=currentFrameContext
-
-    session=session
-    experiment=experiment
-
-    next=(action 'next')
-    previous=(action 'previous')
-    saveHandler=(action 'saveFrame')
-    }}
-</div>
-</div>
-<br>
 <div class="row">
     <div class="col-xs-12">
         {{#if (and (not isFullscreen) experiment.displayFullscreen)}}
@@ -23,3 +5,24 @@
         {{/if}}
     </div>
 </div>
+
+<div class="row" id="experiment-player">
+<div class="col-xs-12">
+    <div id="component-here">
+        {{
+        component currentFrameTemplate
+        frameIndex=frameIndex
+        frameConfig=currentFrameConfig
+        frameContext=currentFrameContext
+
+        session=session
+        experiment=experiment
+
+        next=(action 'next')
+        previous=(action 'previous')
+        saveHandler=(action 'saveFrame')
+        }}
+    </div>
+</div>
+</div>
+


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-161
Companion to: None

## Purpose
Fix issue with frames not setting state correctly

Fix issue with sequence of frames saving frameIDs twice

Return to fullscreen button should be on top of page, not underneath a big item (maximize visibility)

## Testing notes
This fixes an issue where you had to play sound twice to advance frames, as well as issues with the `sequence` property of sessions saved to the server.
