### PR TITLE
Unify videoId implementations in VideoId mixin

### DIFF
--- a/exp-player/addon/components/exp-video-consent.js
+++ b/exp-player/addon/components/exp-video-consent.js
@@ -1,19 +1,12 @@
 import Em from 'ember';
 import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
 import layout from '../templates/components/exp-video-consent';
+import VideoId from '../mixins/video-id';
 
-export default ExpFrameBaseComponent.extend({
+export default ExpFrameBaseComponent.extend(VideoId, {
     layout,
     videoRecorder: Em.inject.service(),
     scroller: Em.inject.service(),
-
-    videoId: function() {
-        return [
-            this.get('experiment.id'),
-            this.get('id'),
-            this.get('session.id')
-        ].join('_');
-    }.property('session', 'id', 'experiment'),
 
     didInsertElement() {
 	this.get('videoRecorder').on('onUploadDone', () => {

--- a/exp-player/addon/components/exp-video-physics.js
+++ b/exp-player/addon/components/exp-video-physics.js
@@ -5,13 +5,14 @@ import layout from '../templates/components/exp-video-physics';
 import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
 import FullScreen from '../mixins/full-screen';
 import MediaReload from '../mixins/media-reload';
+import VideoId from '../mixins/video-id';
 
 let {
     $
 } = Ember;
 
 
-export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, {
+export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoId, {
     layout: layout,
 
     displayFullscreen: true, // force fullscreen for all uses of this component
@@ -33,14 +34,6 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, {
     useAlternate: false,
     currentTask: 'announce', // announce, intro, or test.
     isPaused: false,
-
-    videoId: Ember.computed('session', 'id', 'experiment', function() {
-        return [
-            this.get('experiment.id'),
-            this.get('id'),
-            this.get('session.id')
-        ].join('_');
-    }).volatile(),
 
     videoSources: Ember.computed('isPaused', 'currentTask', 'useAlternate', function() {
             if (this.get('isPaused')) {

--- a/exp-player/addon/components/exp-video-preview.js
+++ b/exp-player/addon/components/exp-video-preview.js
@@ -3,21 +3,13 @@ import Ember from 'ember';
 import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
 import layout from 'exp-player/templates/components/exp-video-preview';
 import MediaReload from 'exp-player/mixins/media-reload';
+import VideoId from '../mixins/video-id';
 
-export default ExpFrameBaseComponent.extend(MediaReload, {
+export default ExpFrameBaseComponent.extend(MediaReload, VideoId, {
     layout,
-
     videoIndex: 0,
 
     videoRecorder: Ember.inject.service(),
-
-    videoId: Ember.computed('session', 'id', 'experiment', function() {
-        return [
-            this.get('experiment.id'),
-            this.get('id'),
-            this.get('session.id')
-        ].join('_');
-    }).volatile(),
 
     noNext: function() {
         return this.get('videoIndex') >= this.get('videos.length') - 1;

--- a/exp-player/addon/components/exp-video-record.js
+++ b/exp-player/addon/components/exp-video-record.js
@@ -5,25 +5,17 @@ import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
 // import FullScreen from '../mixins/full-screen';
 import MediaReload from '../mixins/media-reload';
 import VideoPause from '../mixins/video-pause';
+import VideoId from '../mixins/video-id';
 
 
 //TODO Fullsceen issues/functionality
-export default ExpFrameBaseComponent.extend(MediaReload, VideoPause, {
+export default ExpFrameBaseComponent.extend(MediaReload, VideoPause, VideoId, {
     layout: layout,
     blockUI: false,
     mayProgress: false,
     // displayFullscreen: false,  // force fullscreen for all uses of this component, always
     // fullScreenElementId: 'player-video',
     videoRecorder: Ember.inject.service(),
-
-    videoId: function() {
-        return [
-            this.get('experiment.id'),
-            this.get('id'),
-            this.get('session.id')
-        ].join('_');
-    }.property('session', 'id', 'experiment'),
-
     spaceHandler: null,
     didInsertElement() {
         this._super(...arguments);

--- a/exp-player/addon/mixins/video-id.js
+++ b/exp-player/addon/mixins/video-id.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+    videoId: Ember.computed('session', 'id', 'experiment', function() {
+        return [
+            this.get('experiment.id'),
+            this.get('id'),
+            this.get('session.id')
+        ].join('_');
+    }).volatile()
+});

--- a/exp-player/tests/unit/mixins/video-id-test.js
+++ b/exp-player/tests/unit/mixins/video-id-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import VideoIdMixin from '../../../mixins/video-id';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | video id');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let VideoIdObject = Ember.Object.extend(VideoIdMixin);
+  let subject = VideoIdObject.create();
+  assert.ok(subject);
+});


### PR DESCRIPTION
# Purpose

We had different representations of videoId across different components. Using a mixin helps enforce consistent naming conventions.


