### PR TITLE
Feature: ISP consent form

### DIFF
--- a/exp-player/addon/components/exp-consent.js
+++ b/exp-player/addon/components/exp-consent.js
@@ -25,6 +25,10 @@ export default ExpFrameBaseComponent.extend({
                 consentLabel: {
                     type: 'string',
                     default: 'I agree'
+                },
+                buttonLabel: {
+                    type: 'string',
+                    default: 'Continue'
                 }
             }
         },

--- a/exp-player/addon/components/exp-isp-consent/component.js
+++ b/exp-player/addon/components/exp-isp-consent/component.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import ExpConsentComponent from 'exp-player/components/exp-consent';
+import layout from './template';
+
+
+export default ExpConsentComponent.extend({
+    i18n: Ember.inject.service(),
+    type: 'exp-isp-consent',
+    layout: layout,
+    meta: {
+        name: 'Consent Form',
+        description: 'A simple consent form.',
+        parameters: {
+            type: 'object',
+            properties: {
+                p1: {
+                    type: 'string',
+                    default: 'consent.firstSection'
+                },
+                p2: {
+                    type: 'string',
+                    default: 'consent.secondSection'
+                },
+                p3: {
+                    type: 'string',
+                    default: 'consent.thirdSection'
+                }
+            }
+        },
+        data: {
+            type: 'object',
+            properties: {
+                // data structure defined in exp-consent.js
+            }
+        }
+    }
+});

--- a/exp-player/addon/components/exp-isp-consent/template.hbs
+++ b/exp-player/addon/components/exp-isp-consent/template.hbs
@@ -1,0 +1,19 @@
+<div class="well">
+  <h2>{{t title}}</h2>
+  <hr>
+  <p> {{t p1}}</p>
+  <p> {{t p2}}</p>
+  <p> {{t p3}}</p>
+  <hr>
+  <div class="input-group">
+    {{input type="checkbox" checked=consentGranted}}
+    <span>
+      {{t consentLabel}}
+    </span>
+  </div>
+  <div class="row exp-controls">
+  <button class="btn btn-default pull-right btn-primary" {{ action 'next' }} disabled={{ consentNotGranted }}>
+    {{t buttonLabel}}
+  </button>
+</div>
+</div>

--- a/exp-player/addon/templates/components/exp-consent.hbs
+++ b/exp-player/addon/templates/components/exp-consent.hbs
@@ -12,6 +12,6 @@
 </div>
 <div class="row exp-controls">
   <button class="btn btn-default pull-right" {{ action 'next' }} disabled={{ consentNotGranted }}>
-    Continue
+    {{buttonLabel}}
   </button>
 </div>

--- a/exp-player/app/components/exp-isp-consent.js
+++ b/exp-player/app/components/exp-isp-consent.js
@@ -1,0 +1,2 @@
+import ExpIspConsent from 'exp-player/components/exp-isp-consent/component';
+export default ExpIspConsent;


### PR DESCRIPTION
## Purpose
Add exp-frame for ISP consent from

## Summary of changes
- Make `exp-consent` form button text a variable 
- Add `exp-isp-consent` exp-frame that extends `exp-consent.js` and defines 
  additional properties
- `exp-isp-consent/template.hbs` includes translation helpers


