### PR TITLE
Alternate times in free response questions

### DIFF
--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -29,6 +29,24 @@ export default ExpFrameBaseComponent.extend(Validations, {
     type: 'exp-free-response',
     layout: layout,
     i18n: Ember.inject.service(),
+    displayTime: Ember.computed(function() {
+        var profileId = this.get('session').profileId;
+        if (profileId % 2 === 0) {
+            return this.get('i18n').t('survey.sections.2.times.7pm').string;
+        } else {
+            return this.get('i18n').t('survey.sections.2.times.10am').string;
+        }
+    }),
+    instructions: Ember.computed(function() {
+      var instructions = this.get('i18n').t('survey.sections.2.instructions').string;
+      instructions = instructions.replace('##', this.get('displayTime'));
+      return instructions;
+    }),
+    label1: Ember.computed(function() {
+      var label = this.get('i18n').t('survey.sections.2.questions.11.label').string;
+      label = label.replace('##', this.get('displayTime'));
+      return label;
+    }),
     diff1: Ember.computed('q1', function() {
         var remaining = getRemaining(this.get('q1'));
         var translationKey = 'number' + remaining;

--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -51,7 +51,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
         var remaining = getRemaining(this.get('q1'));
         var translationKey = 'number' + remaining;
         var message = this.get('i18n').t('survey.sections.2.questions.11.characterCount').string;
-        message = message.replace("75", this.get('i18n').t('number75').string);
+        message = message.replace("##", this.get('i18n').t('number75').string);
         message = message.replace("0", this.get('i18n').t(translationKey).string);
         return message;
     }),

--- a/exp-player/addon/components/exp-free-response/template.hbs
+++ b/exp-player/addon/components/exp-free-response/template.hbs
@@ -1,8 +1,8 @@
 <div class="row">
-  <p class="break-line">{{t 'survey.sections.2.instructions'}}</p>
+  <p class="break-line">{{instructions}}</p>
   {{#bs-form}}
     {{#bs-form-group}}
-      <label>{{t 'survey.sections.2.questions.11.label'}}</label>
+      <label>{{label1}}</label>
       {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=q1}}{{/textarea}}
       <p class="text-muted">{{diff1}}</p>
     {{/bs-form-group}}


### PR DESCRIPTION
## Purpose
If a user has an odd profileId, ask them to describe what they were doing at 7pm and if it is even ask what they were doing at 10am.

## Summary of changes
Add computed properties to replace "##" in the translation strings with the correct translated time.

## Testing notes
Requires changes to `en-us/translations.js`(needs variables for 10am & 7pm and ## instead of the hard-coded times), so https://github.com/CenterForOpenScience/isp/pull/32 should be merged first :octocat: 
