### PR TITLE
Remove unnecessary number variables

### DIFF
--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -17,7 +17,7 @@
         {{/draggable-object}}
       {{/each}}
   </div>
-  <h4 class="center">{{t (concat 'number' cards.length)}} {{t 'qsort.sections.1.itemsLeft'}}</h4>
+  <h4 class="center">{{cards.length}} {{t 'qsort.sections.1.itemsLeft'}}</h4>
 {{/if}}
 <div class="row">
     {{#each buckets as |bucket|}}

--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -48,26 +48,20 @@ export default ExpFrameBaseComponent.extend(Validations, {
     }),
     diff1: Ember.computed('q1', function() {
         var remaining = getRemaining(this.get('q1'));
-        var translationKey = 'number' + remaining;
         var message = this.get('i18n').t('survey.sections.2.questions.11.characterCount').string;
-        message = message.replace("##", this.get('i18n').t('number75').string);
-        message = message.replace("0", this.get('i18n').t(translationKey).string);
+        message = message.replace("0", remaining.toString());
         return message;
     }),
     diff2: Ember.computed('q2', function() {
         var remaining = getRemaining(this.get('q2'));
-        var translationKey = 'number' + remaining;
         var message = this.get('i18n').t('survey.sections.2.questions.12.characterCount').string;
-        message = message.replace("##", this.get('i18n').t('number75').string);
-        message = message.replace("0", this.get('i18n').t(translationKey).string);
+        message = message.replace("0", remaining.toString());
         return message;
     }),
     diff3: Ember.computed('q3', function() {
         var remaining = getRemaining(this.get('q3'));
-        var translationKey = 'number' + remaining;
         var message = this.get('i18n').t('survey.sections.2.questions.13.characterCount').string;
-        message = message.replace("##", this.get('i18n').t('number75').string);
-        message = message.replace("0", this.get('i18n').t(translationKey).string);
+        message = message.replace("0", remaining.toString());
         return message;
     }),
     meta: {


### PR DESCRIPTION
 ## Purpose
Since numbers do not need to be translated, remove any translation helpers for the number variables where possible.

## Summary of changes
- Do not translate number of remaining cards in `exp-card-sort` template
- Do not translate remaining characters in `exp-free-response` component