### PR TITLE
Feature: Schema fixes

### DIFF
--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -7,7 +7,7 @@ const MAX_LENGTH = 75;
 
 function getRemaining(value) {
     var length = 0;
-    if (value !== null) {
+    if (value !== undefined) {
         length = value.length;
     }
     return (MAX_LENGTH - length).toString();

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -127,7 +127,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
           type: 'object',
           properties: {
             responses: {
-              type: 'string'
+              type: 'object'
             }
           }
         }

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -578,7 +578,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
             type: 'object',
             properties: {
               responses: {
-                type: 'string'
+                type: 'object'
               }
             }
         }


### PR DESCRIPTION
## Summary of changes
- The exp-overview and exp-rating-form components serialize the data into objects, so meta.data.type should be 'object' not 'string'
- Check for undefined values in exp-free-response