### PR TITLE
Fix getting participantID in free response form

### DIFF
--- a/exp-models/addon/services/current-user.js
+++ b/exp-models/addon/services/current-user.js
@@ -38,7 +38,7 @@ export default Ember.Service.extend({
                             var profile = account.profileById(this.get('session.data.profile.profileId'));
                             if (profile === undefined) {
                                 profile = FakeProfile.create({
-                                    profileId: 'test.user'
+                                    profileId: account.get('username') + '.' + account.get('username')
                                 });
                             }
                             resolve([account, profile]);

--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -29,8 +29,9 @@ export default ExpFrameBaseComponent.extend(Validations, {
     layout: layout,
     i18n: Ember.inject.service(),
     displayTime: Ember.computed(function() {
-        var profileId = this.get('session').profileId;
-        if (profileId % 2 === 0) {
+        var profileId = this.get('session').get('profileId').split('.')[1];
+        var participantId = profileId.split('_')[1];
+        if (participantId % 2 === 0) {
             return this.get('i18n').t('survey.sections.2.times.7pm').string;
         } else {
             return this.get('i18n').t('survey.sections.2.times.10am').string;


### PR DESCRIPTION
#  Changes
- Fix getting participantID in free response form
- Make test profileId accountUsername.accountUsername 


Note: Requires https://github.com/CenterForOpenScience/isp/pull/41 to be merged first