### PR TITLE
Remove form validation to facilitate testing

### DIFF
--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -78,10 +78,10 @@
 </div>
 <div class="row exp-controls">
     {{#if (eq page 'cardSort1')}}
-      <div class="btn btn-primary pull-right {{if (gt cards.length 0) 'disabled'}}" {{action "nextPage"}}>{{t 'global.continueLabel'}}</div>
+      <div class="btn btn-primary pull-right" {{action "nextPage"}}>{{t 'global.continueLabel'}}</div>
       {{progress-bar pageNumber=3}}
     {{else if (eq page 'cardSort2')}}
-      <div class="btn btn-primary pull-right {{if isValid 'enabled' 'disabled'}}" {{ action 'continue' }}>{{t 'global.continueLabel'}}</div>
+      <div class="btn btn-primary pull-right" {{ action 'continue' }}>{{t 'global.continueLabel'}}</div>
       {{progress-bar pageNumber=4}}
     {{/if}}
 </div>

--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -91,11 +91,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
     },
     actions: {
         continue() {
-            if (this.get('validations.isValid')) {
-                this.send('next');
-            } else {
-                this.set('showValidation', true);
-            }
+            this.send('next');
         }
     }
 });

--- a/exp-player/addon/components/exp-free-response/template.hbs
+++ b/exp-player/addon/components/exp-free-response/template.hbs
@@ -21,7 +21,7 @@
 
 </div>
 <div class="row exp-controls">
-    <button class="btn btn-primary pull-right {{if (v-get this 'isInvalid') "disabled"}}" {{ action 'continue' }}>
+    <button class="btn btn-primary pull-right" {{ action 'continue' }}>
         {{t 'global.continueLabel'}}
     </button>
 </div>

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -134,9 +134,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
     },
     actions: {
       continue() {
-        if (this.get('validations.isValid')) {
           this.send('next');
-        }
       }
     }
 });

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -17,5 +17,5 @@
     {{/bs-form}}
 </div>
 <div class="row exp-controls">
-    <button class="btn btn-primary pull-right {{if (v-get this 'isInvalid') "disabled"}}" {{ action 'continue' }}>{{t 'global.continueLabel'}}</button>
+    <button class="btn btn-primary pull-right" {{ action 'continue' }}>{{t 'global.continueLabel'}}</button>
 </div>


### PR DESCRIPTION
## Purpose
To make testing the survey quicker, remove form validation checks so that the entire survey does not have to be completed each time.