### PR TITLE
Feature/paginate rating form [EOSF-153]

### DIFF
--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -4,552 +4,552 @@ import layout from './template';
 import {validator, buildValidations} from 'ember-cp-validations';
 
 var items = {
-  '3': [
-      'measures.questions.3.items.1.label',
-      'measures.questions.3.items.2.label',
-      'measures.questions.3.items.3.label',
-      'measures.questions.3.items.4.label',
-      'measures.questions.3.items.5.label',
-      'measures.questions.3.items.6.label',
-      'measures.questions.3.items.7.label',
-      'measures.questions.3.items.8.label',
-      'measures.questions.3.items.9.label',
-      'measures.questions.3.items.10.label',
-      'measures.questions.3.items.11.label',
-      'measures.questions.3.items.12.label',
-      'measures.questions.3.items.13.label',
-      'measures.questions.3.items.14.label',
-      'measures.questions.3.items.15.label',
-      'measures.questions.3.items.16.label'
-  ],
-  '5': [
-      'measures.questions.5.items.1.label',
-      'measures.questions.5.items.2.label',
-      'measures.questions.5.items.3.label',
-      'measures.questions.5.items.4.label',
-      'measures.questions.5.items.5.label',
-      'measures.questions.5.items.6.label',
-      'measures.questions.5.items.7.label',
-      'measures.questions.5.items.8.label',
-      'measures.questions.5.items.9.label',
-      'measures.questions.5.items.10.label',
-      'measures.questions.5.items.11.label',
-      'measures.questions.5.items.12.label',
-      'measures.questions.5.items.13.label',
-      'measures.questions.5.items.14.label',
-      'measures.questions.5.items.15.label',
-      'measures.questions.5.items.16.label',
-      'measures.questions.5.items.17.label',
-      'measures.questions.5.items.18.label',
-      'measures.questions.5.items.19.label',
-      'measures.questions.5.items.20.label',
-      'measures.questions.5.items.21.label',
-      'measures.questions.5.items.22.label',
-      'measures.questions.5.items.23.label',
-      'measures.questions.5.items.24.label',
-      'measures.questions.5.items.25.label',
-      'measures.questions.5.items.26.label',
-      'measures.questions.5.items.27.label',
-      'measures.questions.5.items.28.label',
-      'measures.questions.5.items.29.label',
-      'measures.questions.5.items.30.label',
-      'measures.questions.5.items.31.label',
-      'measures.questions.5.items.32.label',
-      'measures.questions.5.items.33.label',
-      'measures.questions.5.items.34.label',
-      'measures.questions.5.items.35.label',
-      'measures.questions.5.items.36.label',
-      'measures.questions.5.items.37.label',
-      'measures.questions.5.items.38.label',
-      'measures.questions.5.items.39.label',
-      'measures.questions.5.items.40.label',
-      'measures.questions.5.items.41.label',
-      'measures.questions.5.items.42.label',
-      'measures.questions.5.items.43.label',
-      'measures.questions.5.items.44.label',
-      'measures.questions.5.items.45.label',
-      'measures.questions.5.items.46.label',
-      'measures.questions.5.items.47.label',
-      'measures.questions.5.items.48.label',
-      'measures.questions.5.items.49.label',
-      'measures.questions.5.items.50.label',
-      'measures.questions.5.items.51.label',
-      'measures.questions.5.items.52.label',
-      'measures.questions.5.items.53.label',
-      'measures.questions.5.items.54.label',
-      'measures.questions.5.items.55.label',
-      'measures.questions.5.items.56.label',
-      'measures.questions.5.items.57.label',
-      'measures.questions.5.items.58.label',
-      'measures.questions.5.items.59.label',
-      'measures.questions.5.items.60.label'
-  ],
-  '7': [
-      'measures.questions.7.items.1.label',
-      'measures.questions.7.items.2.label',
-      'measures.questions.7.items.3.label',
-      'measures.questions.7.items.4.label',
-      'measures.questions.7.items.5.label',
-      'measures.questions.7.items.6.label',
-      'measures.questions.7.items.7.label',
-      'measures.questions.7.items.8.label',
-      'measures.questions.7.items.9.label'
-  ],
-  '8': [
-      'measures.questions.8.items.1.label',
-      'measures.questions.8.items.2.label',
-      'measures.questions.8.items.3.label',
-      'measures.questions.8.items.4.label',
-      'measures.questions.8.items.5.label',
-      'measures.questions.8.items.6.label',
-      'measures.questions.8.items.7.label',
-      'measures.questions.8.items.8.label',
-      'measures.questions.8.items.9.label',
-      'measures.questions.8.items.10.label',
-      'measures.questions.8.items.11.label',
-      'measures.questions.8.items.12.label',
-      'measures.questions.8.items.13.label',
-      'measures.questions.8.items.14.label',
-      'measures.questions.8.items.15.label',
-      'measures.questions.8.items.16.label',
-      'measures.questions.8.items.17.label'
-  ],
-  '9': [
-      'measures.questions.9.items.1.label',
-      'measures.questions.9.items.2.label',
-      'measures.questions.9.items.3.label',
-      'measures.questions.9.items.4.label',
-      'measures.questions.9.items.5.label',
-      'measures.questions.9.items.6.label',
-      'measures.questions.9.items.7.label',
-      'measures.questions.9.items.8.label',
-      'measures.questions.9.items.9.label',
-      'measures.questions.9.items.10.label',
-      'measures.questions.9.items.11.label',
-      'measures.questions.9.items.12.label'
-  ],
-  '10': [
-      'measures.questions.10.items.1.label',
-      'measures.questions.10.items.2.label',
-      'measures.questions.10.items.3.label',
-      'measures.questions.10.items.4.label',
-      'measures.questions.10.items.5.label',
-      'measures.questions.10.items.6.label'
-  ],
-  '13': [
-      'measures.questions.13.items.1.label',
-      'measures.questions.13.items.2.label',
-      'measures.questions.13.items.3.label',
-      'measures.questions.13.items.4.label'
-  ],
-  '14': [
-      'measures.questions.14.items.1.label',
-      'measures.questions.14.items.2.label',
-      'measures.questions.14.items.3.label',
-      'measures.questions.14.items.4.label',
-      'measures.questions.14.items.5.label',
-      'measures.questions.14.items.6.label'
-  ],
-  '15': [
-      'measures.questions.15.items.1.label',
-      'measures.questions.15.items.2.label',
-      'measures.questions.15.items.3.label',
-      'measures.questions.15.items.4.label',
-      'measures.questions.15.items.5.label',
-      'measures.questions.15.items.6.label',
-      'measures.questions.15.items.7.label',
-      'measures.questions.15.items.8.label',
-      'measures.questions.15.items.9.label',
-      'measures.questions.15.items.10.label'
-  ],
-  '16': [
-      'measures.questions.16.items.1.label',
-      'measures.questions.16.items.2.label',
-      'measures.questions.16.items.3.label',
-      'measures.questions.16.items.4.label',
-      'measures.questions.16.items.5.label'
-  ],
-  '17': [
-      'measures.questions.17.items.1.label',
-      'measures.questions.17.items.2.label',
-      'measures.questions.17.items.3.label',
-      'measures.questions.17.items.4.label',
-      'measures.questions.17.items.5.label',
-      'measures.questions.17.items.6.label'
-  ]
+    '3': [
+        'measures.questions.3.items.1.label',
+        'measures.questions.3.items.2.label',
+        'measures.questions.3.items.3.label',
+        'measures.questions.3.items.4.label',
+        'measures.questions.3.items.5.label',
+        'measures.questions.3.items.6.label',
+        'measures.questions.3.items.7.label',
+        'measures.questions.3.items.8.label',
+        'measures.questions.3.items.9.label',
+        'measures.questions.3.items.10.label',
+        'measures.questions.3.items.11.label',
+        'measures.questions.3.items.12.label',
+        'measures.questions.3.items.13.label',
+        'measures.questions.3.items.14.label',
+        'measures.questions.3.items.15.label',
+        'measures.questions.3.items.16.label'
+    ],
+    '5': [
+        'measures.questions.5.items.1.label',
+        'measures.questions.5.items.2.label',
+        'measures.questions.5.items.3.label',
+        'measures.questions.5.items.4.label',
+        'measures.questions.5.items.5.label',
+        'measures.questions.5.items.6.label',
+        'measures.questions.5.items.7.label',
+        'measures.questions.5.items.8.label',
+        'measures.questions.5.items.9.label',
+        'measures.questions.5.items.10.label',
+        'measures.questions.5.items.11.label',
+        'measures.questions.5.items.12.label',
+        'measures.questions.5.items.13.label',
+        'measures.questions.5.items.14.label',
+        'measures.questions.5.items.15.label',
+        'measures.questions.5.items.16.label',
+        'measures.questions.5.items.17.label',
+        'measures.questions.5.items.18.label',
+        'measures.questions.5.items.19.label',
+        'measures.questions.5.items.20.label',
+        'measures.questions.5.items.21.label',
+        'measures.questions.5.items.22.label',
+        'measures.questions.5.items.23.label',
+        'measures.questions.5.items.24.label',
+        'measures.questions.5.items.25.label',
+        'measures.questions.5.items.26.label',
+        'measures.questions.5.items.27.label',
+        'measures.questions.5.items.28.label',
+        'measures.questions.5.items.29.label',
+        'measures.questions.5.items.30.label',
+        'measures.questions.5.items.31.label',
+        'measures.questions.5.items.32.label',
+        'measures.questions.5.items.33.label',
+        'measures.questions.5.items.34.label',
+        'measures.questions.5.items.35.label',
+        'measures.questions.5.items.36.label',
+        'measures.questions.5.items.37.label',
+        'measures.questions.5.items.38.label',
+        'measures.questions.5.items.39.label',
+        'measures.questions.5.items.40.label',
+        'measures.questions.5.items.41.label',
+        'measures.questions.5.items.42.label',
+        'measures.questions.5.items.43.label',
+        'measures.questions.5.items.44.label',
+        'measures.questions.5.items.45.label',
+        'measures.questions.5.items.46.label',
+        'measures.questions.5.items.47.label',
+        'measures.questions.5.items.48.label',
+        'measures.questions.5.items.49.label',
+        'measures.questions.5.items.50.label',
+        'measures.questions.5.items.51.label',
+        'measures.questions.5.items.52.label',
+        'measures.questions.5.items.53.label',
+        'measures.questions.5.items.54.label',
+        'measures.questions.5.items.55.label',
+        'measures.questions.5.items.56.label',
+        'measures.questions.5.items.57.label',
+        'measures.questions.5.items.58.label',
+        'measures.questions.5.items.59.label',
+        'measures.questions.5.items.60.label'
+    ],
+    '7': [
+        'measures.questions.7.items.1.label',
+        'measures.questions.7.items.2.label',
+        'measures.questions.7.items.3.label',
+        'measures.questions.7.items.4.label',
+        'measures.questions.7.items.5.label',
+        'measures.questions.7.items.6.label',
+        'measures.questions.7.items.7.label',
+        'measures.questions.7.items.8.label',
+        'measures.questions.7.items.9.label'
+    ],
+    '8': [
+        'measures.questions.8.items.1.label',
+        'measures.questions.8.items.2.label',
+        'measures.questions.8.items.3.label',
+        'measures.questions.8.items.4.label',
+        'measures.questions.8.items.5.label',
+        'measures.questions.8.items.6.label',
+        'measures.questions.8.items.7.label',
+        'measures.questions.8.items.8.label',
+        'measures.questions.8.items.9.label',
+        'measures.questions.8.items.10.label',
+        'measures.questions.8.items.11.label',
+        'measures.questions.8.items.12.label',
+        'measures.questions.8.items.13.label',
+        'measures.questions.8.items.14.label',
+        'measures.questions.8.items.15.label',
+        'measures.questions.8.items.16.label',
+        'measures.questions.8.items.17.label'
+    ],
+    '9': [
+        'measures.questions.9.items.1.label',
+        'measures.questions.9.items.2.label',
+        'measures.questions.9.items.3.label',
+        'measures.questions.9.items.4.label',
+        'measures.questions.9.items.5.label',
+        'measures.questions.9.items.6.label',
+        'measures.questions.9.items.7.label',
+        'measures.questions.9.items.8.label',
+        'measures.questions.9.items.9.label',
+        'measures.questions.9.items.10.label',
+        'measures.questions.9.items.11.label',
+        'measures.questions.9.items.12.label'
+    ],
+    '10': [
+        'measures.questions.10.items.1.label',
+        'measures.questions.10.items.2.label',
+        'measures.questions.10.items.3.label',
+        'measures.questions.10.items.4.label',
+        'measures.questions.10.items.5.label',
+        'measures.questions.10.items.6.label'
+    ],
+    '13': [
+        'measures.questions.13.items.1.label',
+        'measures.questions.13.items.2.label',
+        'measures.questions.13.items.3.label',
+        'measures.questions.13.items.4.label'
+    ],
+    '14': [
+        'measures.questions.14.items.1.label',
+        'measures.questions.14.items.2.label',
+        'measures.questions.14.items.3.label',
+        'measures.questions.14.items.4.label',
+        'measures.questions.14.items.5.label',
+        'measures.questions.14.items.6.label'
+    ],
+    '15': [
+        'measures.questions.15.items.1.label',
+        'measures.questions.15.items.2.label',
+        'measures.questions.15.items.3.label',
+        'measures.questions.15.items.4.label',
+        'measures.questions.15.items.5.label',
+        'measures.questions.15.items.6.label',
+        'measures.questions.15.items.7.label',
+        'measures.questions.15.items.8.label',
+        'measures.questions.15.items.9.label',
+        'measures.questions.15.items.10.label'
+    ],
+    '16': [
+        'measures.questions.16.items.1.label',
+        'measures.questions.16.items.2.label',
+        'measures.questions.16.items.3.label',
+        'measures.questions.16.items.4.label',
+        'measures.questions.16.items.5.label'
+    ],
+    '17': [
+        'measures.questions.17.items.1.label',
+        'measures.questions.17.items.2.label',
+        'measures.questions.17.items.3.label',
+        'measures.questions.17.items.4.label',
+        'measures.questions.17.items.5.label',
+        'measures.questions.17.items.6.label'
+    ]
 };
 
 const TEN_POINT_SCALE = [
-  'number0',
-  'number1',
-  'number2',
-  'number3',
-  'number4',
-  'number5',
-  'number6',
-  'number7',
-  'number8',
-  'number9',
-  'number10'
+    'number0',
+    'number1',
+    'number2',
+    'number3',
+    'number4',
+    'number5',
+    'number6',
+    'number7',
+    'number8',
+    'number9',
+    'number10'
 ];
 const SEVEN_POINT_SCALE = TEN_POINT_SCALE.slice(0, 8);
 const NINE_POINT_SCALE = TEN_POINT_SCALE.slice(0, 10);
 
-var generateValidators = function(questions) {
-  var validators = {};
-  var presence = validator('presence', {
-      presence:true,
-      message: 'This field is required'
-  });
-  for (var i=0; i < questions.length; i++) {
-    for (var item=0; item < questions[i]['items'].length; item++) {
-      var isOptional = questions[i]['items'][item].optional;
-      if (!isOptional) {
-        var key = `questions.${i}.items.${item}.value`;
-        validators[key] = presence;
-      }
+var generateValidators = function (questions) {
+    var validators = {};
+    var presence = validator('presence', {
+        presence: true,
+        message: 'This field is required'
+    });
+    for (var i = 0; i < questions.length; i++) {
+        for (var item = 0; item < questions[i]['items'].length; item++) {
+            var isOptional = questions[i]['items'][item].optional;
+            if (!isOptional) {
+                var key = `questions.${i}.items.${item}.value`;
+                validators[key] = presence;
+            }
+        }
     }
-  }
-  return validators;
+    return validators;
 };
 
-var generateSchema = function(data) {
-  var items = [];
-  var options = data.options ? data.options : {};
-  for (var i=0; i < data.items.length; i++) {
-    var ret = {
-          description: data.items[i],
-          value: null
-      };
-    for (var option in options) {
-      if (options.hasOwnProperty(option)) {
-        ret[option] = options[option];
-      }
+var generateSchema = function (data) {
+    var items = [];
+    var options = data.options ? data.options : {};
+    for (var i = 0; i < data.items.length; i++) {
+        var ret = {
+            description: data.items[i],
+            value: null
+        };
+        for (var option in options) {
+            if (options.hasOwnProperty(option)) {
+                ret[option] = options[option];
+            }
+        }
+        items.push(ret);
     }
-    items.push(ret);
-  }
-  data['items'] = items;
-  return data;
+    data['items'] = items;
+    return data;
 };
 
 var questions = [
-  generateSchema({
-    question: 'measures.questions.1.label',
-    type: 'select',
-    page: 1,
-    items: [''],
-    scale: [
-      'measures.questions.1.options.extremelyNeg',
-      'measures.questions.1.options.quiteNeg',
-      'measures.questions.1.options.fairlyNeg',
-      'measures.questions.1.options.somewhatNeg',
-      'measures.questions.1.options.neither',
-      'measures.questions.1.options.somewhatPos',
-      'measures.questions.1.options.fairlyPos',
-      'measures.questions.1.options.quitePos',
-      'measures.questions.1.options.extremelyPos'
-    ]
-  }),
-  generateSchema({
-    question: 'measures.questions.2.label',
-    type: 'radio',
-    page: 1,
-    items: [''],
-    scale: SEVEN_POINT_SCALE,
-    options: {
-      labelTop: false,
-      labels: [{
-          rating: 0,
-          label:'measures.questions.2.options.never'
-        },
-        {
-          rating: 2,
-          label: 'measures.questions.2.options.hardlyEver'
-        },
-        {
-          rating: 4,
-          label: 'measures.questions.2.options.occasionally'
-        },
-        {
-          rating: 6,
-          label: 'measures.questions.2.options.quiteOften'
-        }
-      ]
-    }
-  }),
-  generateSchema({
-    question: 'measures.questions.3.label.10am',
-    type: 'radio',
-    page: 1,
-    items: items['3'],
-    scale: [
-      'measures.questions.3.options.extremelyUnchar',
-      'measures.questions.3.options.quiteUnchar',
-      'measures.questions.3.options.fairlyUnchar',
-      'measures.questions.3.options.somewhatUnchar',
-      'measures.questions.3.options.neutral',
-      'measures.questions.3.options.somewhatChar',
-      'measures.questions.3.options.fairlyChar',
-      'measures.questions.3.options.quiteChar',
-      'measures.questions.3.options.extremelyChar'
-    ],
-    options: {
-      labelTop: true,
-      formatLabel: true
-    }
-  }),
-  generateSchema({
-    question: 'measures.questions.4.label',
-    type: 'radio',
-    page: 2,
-    items: [''],
-    scale: TEN_POINT_SCALE,
-    options: {
-      labelTop: false,
-      labels: [{
-          rating: 0,
-          label: 'measures.questions.4.options.unwilling'
-        },
-        {
-          rating: 10,
-          label: 'measures.questions.4.options.fullyPrepared'
-        }
-      ]
-    }
-  }),
-  generateSchema({
-    question: 'measures.questions.5.label',
-    type: 'radio',
-    page: 2,
-    items: items['5'],
-    scale: [
-      'measures.questions.5.options.disagreeStrongly',
-      'measures.questions.5.options.disagree',
-      'measures.questions.5.options.neutral',
-      'measures.questions.5.options.agree',
-      'measures.questions.5.options.agreeStrongly'
-    ],
-    options: {labelTop: true}
-  }),
-  {
-    question: 'measures.questions.6.label',
-    type: 'radio',
-    page: 3,
-    scale: SEVEN_POINT_SCALE,
-    items: [
-      {
-        description: 'measures.questions.6.items.1.label',
-        value:null,
-        labelTop: false,
-        labels: [{
-            rating: 0,
-            label: 'measures.questions.6.items.1.options.notHappy'
-          },
-          {
-            rating: 7,
-            label: 'measures.questions.6.items.1.options.veryHappy'
-          }]
-      },
-      {
-        description: 'measures.questions.6.items.2.label',
-        scale: SEVEN_POINT_SCALE,
-        value:null,
-        labelTop: false,
-        labels: [{
-            rating: 0,
-            label: 'measures.questions.6.items.2.options.lessHappy'
-          },
-          {
-            rating: 7,
-            label: 'measures.questions.6.items.2.options.moreHappy'
-          }]
-      },
-      {
-        description: 'measures.questions.6.items.3.label',
-        scale: SEVEN_POINT_SCALE,
-        value:null,
-        labelTop: false,
-        labels: [{
-            rating: 0,
-            label: 'measures.questions.6.items.4.options.notAtAll'
-          },
-          {
-            rating: 7,
-            label: 'measures.questions.6.items.4.options.aGreatDeal'
-          }]
-      },
-      {
-        description:'measures.questions.6.items.4.label',
-        scale: SEVEN_POINT_SCALE,
-        value:null,
-        labelTop: false,
-        labels: [{
-            rating: 0,
-            label: 'measures.questions.6.items.4.options.notAtAll'
-          },
-          {
-            rating: 7,
-            label: 'measures.questions.6.items.4.options.aGreatDeal'
-          }]
-      }]
-  },
-  generateSchema({
-    question: 'measures.questions.7.label',
-    type: 'radio',
-    page: 3,
-    items: items['7'],
-    scale: [
-      'measures.questions.7.options.disagreeStrongly',
-      'measures.questions.7.options.disagree',
-      'measures.questions.7.options.neutral',
-      'measures.questions.7.options.agree',
-      'measures.questions.7.options.agreeStrongly'
-    ],
-    options: {labelTop: true}
-  }),
-  generateSchema({
-    question: 'measures.questions.8.label',
-    type: 'radio',
-    page: 4,
-    items: items['8'],
-    scale: [
-      'measures.questions.8.options.disbelieveStrong',
-      'measures.questions.8.options.disbelieveLittle',
-      'measures.questions.8.options.neutral',
-      'measures.questions.8.options.believeLittle',
-      'measures.questions.8.options.believeStrong'
-    ],
-    options: {labelTop: true}
-  }),
-  generateSchema({
-    question:'measures.questions.9.label',
-    type: 'radio',
-    page: 5,
-    items: items['9'],
-    scale: NINE_POINT_SCALE,
-    options: {
-        labelTop: false,
-        labels: [{
-            rating: 0,
-            label: 'measures.questions.9.options.notAtAll'
-        },
-            {
-                rating: 3,
-                label: 'measures.questions.9.options.aLittle'
-            },
-            {
-                rating: 5,
-                label: 'measures.questions.9.options.moderately'
-            },
-            {
-                rating: 7,
-                label: 'measures.questions.9.options.veryWell'
-            },
-            {
-                rating: 9,
-                label: 'measures.questions.9.options.exactly'
-            }]
-    }
-  }),
-  generateSchema({
-    question: 'measures.questions.10.label',
-    type: 'radio',
-    page: 5,
-    items: items['10'],
-    scale: [
-      'measures.questions.10.options.disagreeStrongly',
-      'measures.questions.10.options.disagree',
-      'measures.questions.10.options.neutral',
-      'measures.questions.10.options.agree',
-      'measures.questions.10.options.agreeStrongly'
-    ],
-    options: {labelTop: true}
-  }),
-  {
-    question: 'measures.questions.11.label',
-    type: 'radio-input',
-    page: 5,
-    scale: ['measures.questions.11.options.yes', 'measures.questions.11.options.no'],
-    items: [{
+    generateSchema({
+        question: 'measures.questions.1.label',
+        type: 'select',
+        page: 1,
+        items: [''],
+        scale: [
+            'measures.questions.1.options.extremelyNeg',
+            'measures.questions.1.options.quiteNeg',
+            'measures.questions.1.options.fairlyNeg',
+            'measures.questions.1.options.somewhatNeg',
+            'measures.questions.1.options.neither',
+            'measures.questions.1.options.somewhatPos',
+            'measures.questions.1.options.fairlyPos',
+            'measures.questions.1.options.quitePos',
+            'measures.questions.1.options.extremelyPos'
+        ]
+    }),
+    generateSchema({
+        question: 'measures.questions.2.label',
         type: 'radio',
-        value: null
-      },
-      {
-        type: 'input',
-        description: 'measures.questions.12.label',
-        value:null,
-        optional:true
-    }]
-  },
-  generateSchema({
-    question: 'measures.questions.13.label',
-    type: 'radio',
-    page: 6,
-    items: items['13'],
-    scale: [
-      'measures.questions.13.options.disagreeStrongly',
-      'measures.questions.13.options.disagree',
-      'measures.questions.13.options.neutral',
-      'measures.questions.13.options.agree',
-      'measures.questions.13.options.agreeStrongly'
-    ],
-    options: {labelTop: true}
-  }),
-  generateSchema({
-    question: 'measures.questions.14.label',
-    type: 'radio',
-    page: 6,
-    items: items['14'],
-    scale: [
-      'measures.questions.14.options.disagreeStrongly',
-      'measures.questions.14.options.disagree',
-      'measures.questions.14.options.neutral',
-      'measures.questions.14.options.agree',
-      'measures.questions.14.options.agreeStrongly'
-    ],
-    options: {labelTop: true}
-  }),
-  generateSchema({
-    question: 'measures.questions.15.label',
-    type: 'radio',
-    page: 6,
-    items: items['15'],
-    scale: [
-      'measures.questions.15.options.disagreeStrongly',
-      'measures.questions.15.options.disagree',
-      'measures.questions.15.options.neutral',
-      'measures.questions.15.options.agree',
-      'measures.questions.15.options.agreeStrongly'
-    ],
-    options: {labelTop: true}
-  }),
-  generateSchema({
-    question: 'measures.questions.16.label',
-    type: 'radio',
-    page: 7,
-    items: items['16'],
-    scale: [
-      'measures.questions.16.options.notAtAll',
-      'measures.questions.16.options.aLittle',
-      'measures.questions.16.options.quiteaBit',
-      'measures.questions.16.options.completely'
-    ],
-    options: {labelTop: true}
-  }),
-  generateSchema({
-    question: 'measures.questions.17.label',
-    type: 'radio',
-    page: 7,
-    items: items['17'],
-    scale: [
-      'measures.questions.17.options.disagreeStrongly',
-      'measures.questions.17.options.disagree',
-      'measures.questions.17.options.neutral',
-      'measures.questions.17.options.agree',
-      'measures.questions.17.options.agreeStrongly'
-    ],
-    options: {labelTop: true}
-  })
+        page: 1,
+        items: [''],
+        scale: SEVEN_POINT_SCALE,
+        options: {
+            labelTop: false,
+            labels: [{
+                rating: 0,
+                label: 'measures.questions.2.options.never'
+            },
+                {
+                    rating: 2,
+                    label: 'measures.questions.2.options.hardlyEver'
+                },
+                {
+                    rating: 4,
+                    label: 'measures.questions.2.options.occasionally'
+                },
+                {
+                    rating: 6,
+                    label: 'measures.questions.2.options.quiteOften'
+                }
+            ]
+        }
+    }),
+    generateSchema({
+        question: 'measures.questions.3.label.10am',
+        type: 'radio',
+        page: 1,
+        items: items['3'],
+        scale: [
+            'measures.questions.3.options.extremelyUnchar',
+            'measures.questions.3.options.quiteUnchar',
+            'measures.questions.3.options.fairlyUnchar',
+            'measures.questions.3.options.somewhatUnchar',
+            'measures.questions.3.options.neutral',
+            'measures.questions.3.options.somewhatChar',
+            'measures.questions.3.options.fairlyChar',
+            'measures.questions.3.options.quiteChar',
+            'measures.questions.3.options.extremelyChar'
+        ],
+        options: {
+            labelTop: true,
+            formatLabel: true
+        }
+    }),
+    generateSchema({
+        question: 'measures.questions.4.label',
+        type: 'radio',
+        page: 2,
+        items: [''],
+        scale: TEN_POINT_SCALE,
+        options: {
+            labelTop: false,
+            labels: [{
+                rating: 0,
+                label: 'measures.questions.4.options.unwilling'
+            },
+                {
+                    rating: 10,
+                    label: 'measures.questions.4.options.fullyPrepared'
+                }
+            ]
+        }
+    }),
+    generateSchema({
+        question: 'measures.questions.5.label',
+        type: 'radio',
+        page: 2,
+        items: items['5'],
+        scale: [
+            'measures.questions.5.options.disagreeStrongly',
+            'measures.questions.5.options.disagree',
+            'measures.questions.5.options.neutral',
+            'measures.questions.5.options.agree',
+            'measures.questions.5.options.agreeStrongly'
+        ],
+        options: {labelTop: true}
+    }),
+    {
+        question: 'measures.questions.6.label',
+        type: 'radio',
+        page: 3,
+        scale: SEVEN_POINT_SCALE,
+        items: [
+            {
+                description: 'measures.questions.6.items.1.label',
+                value: null,
+                labelTop: false,
+                labels: [{
+                    rating: 0,
+                    label: 'measures.questions.6.items.1.options.notHappy'
+                },
+                    {
+                        rating: 7,
+                        label: 'measures.questions.6.items.1.options.veryHappy'
+                    }]
+            },
+            {
+                description: 'measures.questions.6.items.2.label',
+                scale: SEVEN_POINT_SCALE,
+                value: null,
+                labelTop: false,
+                labels: [{
+                    rating: 0,
+                    label: 'measures.questions.6.items.2.options.lessHappy'
+                },
+                    {
+                        rating: 7,
+                        label: 'measures.questions.6.items.2.options.moreHappy'
+                    }]
+            },
+            {
+                description: 'measures.questions.6.items.3.label',
+                scale: SEVEN_POINT_SCALE,
+                value: null,
+                labelTop: false,
+                labels: [{
+                    rating: 0,
+                    label: 'measures.questions.6.items.4.options.notAtAll'
+                },
+                    {
+                        rating: 7,
+                        label: 'measures.questions.6.items.4.options.aGreatDeal'
+                    }]
+            },
+            {
+                description: 'measures.questions.6.items.4.label',
+                scale: SEVEN_POINT_SCALE,
+                value: null,
+                labelTop: false,
+                labels: [{
+                    rating: 0,
+                    label: 'measures.questions.6.items.4.options.notAtAll'
+                },
+                    {
+                        rating: 7,
+                        label: 'measures.questions.6.items.4.options.aGreatDeal'
+                    }]
+            }]
+    },
+    generateSchema({
+        question: 'measures.questions.7.label',
+        type: 'radio',
+        page: 3,
+        items: items['7'],
+        scale: [
+            'measures.questions.7.options.disagreeStrongly',
+            'measures.questions.7.options.disagree',
+            'measures.questions.7.options.neutral',
+            'measures.questions.7.options.agree',
+            'measures.questions.7.options.agreeStrongly'
+        ],
+        options: {labelTop: true}
+    }),
+    generateSchema({
+        question: 'measures.questions.8.label',
+        type: 'radio',
+        page: 4,
+        items: items['8'],
+        scale: [
+            'measures.questions.8.options.disbelieveStrong',
+            'measures.questions.8.options.disbelieveLittle',
+            'measures.questions.8.options.neutral',
+            'measures.questions.8.options.believeLittle',
+            'measures.questions.8.options.believeStrong'
+        ],
+        options: {labelTop: true}
+    }),
+    generateSchema({
+        question: 'measures.questions.9.label',
+        type: 'radio',
+        page: 5,
+        items: items['9'],
+        scale: NINE_POINT_SCALE,
+        options: {
+            labelTop: false,
+            labels: [{
+                rating: 0,
+                label: 'measures.questions.9.options.notAtAll'
+            },
+                {
+                    rating: 3,
+                    label: 'measures.questions.9.options.aLittle'
+                },
+                {
+                    rating: 5,
+                    label: 'measures.questions.9.options.moderately'
+                },
+                {
+                    rating: 7,
+                    label: 'measures.questions.9.options.veryWell'
+                },
+                {
+                    rating: 9,
+                    label: 'measures.questions.9.options.exactly'
+                }]
+        }
+    }),
+    generateSchema({
+        question: 'measures.questions.10.label',
+        type: 'radio',
+        page: 5,
+        items: items['10'],
+        scale: [
+            'measures.questions.10.options.disagreeStrongly',
+            'measures.questions.10.options.disagree',
+            'measures.questions.10.options.neutral',
+            'measures.questions.10.options.agree',
+            'measures.questions.10.options.agreeStrongly'
+        ],
+        options: {labelTop: true}
+    }),
+    {
+        question: 'measures.questions.11.label',
+        type: 'radio-input',
+        page: 5,
+        scale: ['measures.questions.11.options.yes', 'measures.questions.11.options.no'],
+        items: [{
+            type: 'radio',
+            value: null
+        },
+            {
+                type: 'input',
+                description: 'measures.questions.12.label',
+                value: null,
+                optional: true
+            }]
+    },
+    generateSchema({
+        question: 'measures.questions.13.label',
+        type: 'radio',
+        page: 6,
+        items: items['13'],
+        scale: [
+            'measures.questions.13.options.disagreeStrongly',
+            'measures.questions.13.options.disagree',
+            'measures.questions.13.options.neutral',
+            'measures.questions.13.options.agree',
+            'measures.questions.13.options.agreeStrongly'
+        ],
+        options: {labelTop: true}
+    }),
+    generateSchema({
+        question: 'measures.questions.14.label',
+        type: 'radio',
+        page: 6,
+        items: items['14'],
+        scale: [
+            'measures.questions.14.options.disagreeStrongly',
+            'measures.questions.14.options.disagree',
+            'measures.questions.14.options.neutral',
+            'measures.questions.14.options.agree',
+            'measures.questions.14.options.agreeStrongly'
+        ],
+        options: {labelTop: true}
+    }),
+    generateSchema({
+        question: 'measures.questions.15.label',
+        type: 'radio',
+        page: 6,
+        items: items['15'],
+        scale: [
+            'measures.questions.15.options.disagreeStrongly',
+            'measures.questions.15.options.disagree',
+            'measures.questions.15.options.neutral',
+            'measures.questions.15.options.agree',
+            'measures.questions.15.options.agreeStrongly'
+        ],
+        options: {labelTop: true}
+    }),
+    generateSchema({
+        question: 'measures.questions.16.label',
+        type: 'radio',
+        page: 7,
+        items: items['16'],
+        scale: [
+            'measures.questions.16.options.notAtAll',
+            'measures.questions.16.options.aLittle',
+            'measures.questions.16.options.quiteaBit',
+            'measures.questions.16.options.completely'
+        ],
+        options: {labelTop: true}
+    }),
+    generateSchema({
+        question: 'measures.questions.17.label',
+        type: 'radio',
+        page: 7,
+        items: items['17'],
+        scale: [
+            'measures.questions.17.options.disagreeStrongly',
+            'measures.questions.17.options.disagree',
+            'measures.questions.17.options.neutral',
+            'measures.questions.17.options.agree',
+            'measures.questions.17.options.agreeStrongly'
+        ],
+        options: {labelTop: true}
+    })
 ];
 
 const Validations = buildValidations(generateValidators(questions));
@@ -559,10 +559,10 @@ export default ExpFrameBaseComponent.extend(Validations, {
     layout: layout,
     currentPage: 1,
     totalPages: 7,
-    progressBarPage: Ember.computed('currentPage', function() {
+    progressBarPage: Ember.computed('currentPage', function () {
         return this.currentPage + 4;
     }),
-    questions: Ember.computed(function() {
+    questions: Ember.computed(function () {
         var condition = this.get('session').get('experimentCondition');
         if (condition === '7pm') {
             questions[2]['question'] = 'measures.questions.3.label.7pm';
@@ -571,13 +571,13 @@ export default ExpFrameBaseComponent.extend(Validations, {
         }
         return questions;
     }),
-    responses: Ember.computed('currentPage', function() {
+    responses: Ember.computed('currentPage', function () {
         var questions = this.get('questions');
         var responses = {};
-        for (var i=0; i < questions.length; i++) {
+        for (var i = 0; i < questions.length; i++) {
             var question = questions[i];
             responses[i] = {};
-            for (var j=0; j < question.items.length; j++) {
+            for (var j = 0; j < question.items.length; j++) {
                 responses[i][j] = question.items[j].value;
             }
         }
@@ -595,9 +595,9 @@ export default ExpFrameBaseComponent.extend(Validations, {
         data: {
             type: 'object',
             properties: {
-              responses: {
-                type: 'object'
-              }
+                responses: {
+                    type: 'object'
+                }
             }
         }
     },

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -283,7 +283,7 @@ var questions = [
     page: 1,
     items: items['3'],
     scale: [
-      'measures.questions.3.options.extremelyChar',
+      'measures.questions.3.options.extremelyUnchar',
       'measures.questions.3.options.quiteUnchar',
       'measures.questions.3.options.fairlyUnchar',
       'measures.questions.3.options.somewhatUnchar',
@@ -470,16 +470,16 @@ var questions = [
     type: 'radio-input',
     page: 5,
     scale: ['measures.questions.11.options.yes', 'measures.questions.11.options.no'],
-    items: {
-      radio: {
+    items: [{
+        type: 'radio',
         value: null
       },
-      input: {
+      {
+        type: 'input',
         description: 'measures.questions.12.label',
         value:null,
         optional:true
-      }
-    }
+    }]
   },
   generateSchema({
     question: 'measures.questions.13.label',
@@ -571,7 +571,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
         }
         return questions;
     }),
-    responses: Ember.computed('questions', function() {
+    responses: Ember.computed('currentPage', function() {
         var questions = this.get('questions');
         var responses = {};
         for (var i=0; i < questions.length; i++) {
@@ -604,6 +604,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
     actions: {
         nextPage() {
             this.set('currentPage', this.currentPage + 1);
+            this.send('save');
         }
     }
 });

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -213,34 +213,32 @@ var generateValidators = function(questions) {
   return validators;
 };
 
-var generateSchema = function(question, type, page, items, scale, options) {
-  var schema = {
-    question: question,
-    type: type,
-    page: page,
-    scale: scale,
-    items: []
-  };
-  for (var i=0; i < items.length; i++) {
+var generateSchema = function(data) {
+  var items = [];
+  var options = data.options ? data.options : {};
+  for (var i=0; i < data.items.length; i++) {
     var ret = {
-      description: items[i],
-      value: null
-    };
+          description: data.items[i],
+          value: null
+      };
     for (var option in options) {
-      ret[option] = options[option];
+      if (options.hasOwnProperty(option)) {
+        ret[option] = options[option];
+      }
     }
-    schema['items'].push(ret);
+    items.push(ret);
   }
-  return schema;
+  data['items'] = items;
+  return data;
 };
 
 var questions = [
-  generateSchema(
-    'measures.questions.1.label',
-    'select',
-     1,
-    [''],
-    [
+  generateSchema({
+    question: 'measures.questions.1.label',
+    type: 'select',
+    page: 1,
+    items: [''],
+    scale: [
       'measures.questions.1.options.extremelyNeg',
       'measures.questions.1.options.quiteNeg',
       'measures.questions.1.options.fairlyNeg',
@@ -251,14 +249,14 @@ var questions = [
       'measures.questions.1.options.quitePos',
       'measures.questions.1.options.extremelyPos'
     ]
-  ),
-  generateSchema(
-    'measures.questions.2.label',
-    'radio',
-      1,
-    [''],
-    SEVEN_POINT_SCALE,
-    {
+  }),
+  generateSchema({
+    question: 'measures.questions.2.label',
+    type: 'radio',
+    page: 1,
+    items: [''],
+    scale: SEVEN_POINT_SCALE,
+    options: {
       labelTop: false,
       labels: [{
           rating: 0,
@@ -278,13 +276,13 @@ var questions = [
         }
       ]
     }
-  ),
-  generateSchema(
-    'measures.questions.3.label.10am',
-    'radio',
-      1,
-    items['3'],
-    [
+  }),
+  generateSchema({
+    question: 'measures.questions.3.label.10am',
+    type: 'radio',
+    page: 1,
+    items: items['3'],
+    scale: [
       'measures.questions.3.options.extremelyChar',
       'measures.questions.3.options.quiteUnchar',
       'measures.questions.3.options.fairlyUnchar',
@@ -295,18 +293,18 @@ var questions = [
       'measures.questions.3.options.quiteChar',
       'measures.questions.3.options.extremelyChar'
     ],
-    {
-        labelTop: true,
-        formatLabel: true
+    options: {
+      labelTop: true,
+      formatLabel: true
     }
-  ),
-  generateSchema(
-    'measures.questions.4.label',
-    'radio',
-      2,
-    [''],
-    TEN_POINT_SCALE,
-    {
+  }),
+  generateSchema({
+    question: 'measures.questions.4.label',
+    type: 'radio',
+    page: 2,
+    items: [''],
+    scale: TEN_POINT_SCALE,
+    options: {
       labelTop: false,
       labels: [{
           rating: 0,
@@ -318,21 +316,21 @@ var questions = [
         }
       ]
     }
-  ),
-  generateSchema(
-    'measures.questions.5.label',
-    'radio',
-      2,
-    items['5'],
-    [
+  }),
+  generateSchema({
+    question: 'measures.questions.5.label',
+    type: 'radio',
+    page: 2,
+    items: items['5'],
+    scale: [
       'measures.questions.5.options.disagreeStrongly',
       'measures.questions.5.options.disagree',
       'measures.questions.5.options.neutral',
       'measures.questions.5.options.agree',
       'measures.questions.5.options.agreeStrongly'
     ],
-    {labelTop: true}
-  ),
+    options: {labelTop: true}
+  }),
   {
     question: 'measures.questions.6.label',
     type: 'radio',
@@ -395,78 +393,78 @@ var questions = [
           }]
       }]
   },
-  generateSchema(
-    'measures.questions.7.label',
-    'radio',
-      3,
-    items['7'],
-    [
+  generateSchema({
+    question: 'measures.questions.7.label',
+    type: 'radio',
+    page: 3,
+    items: items['7'],
+    scale: [
       'measures.questions.7.options.disagreeStrongly',
       'measures.questions.7.options.disagree',
       'measures.questions.7.options.neutral',
       'measures.questions.7.options.agree',
       'measures.questions.7.options.agreeStrongly'
     ],
-    {labelTop: true}
-  ),
-  generateSchema(
-    'measures.questions.8.label',
-    'radio',
-      4,
-    items['8'],
-    [
+    options: {labelTop: true}
+  }),
+  generateSchema({
+    question: 'measures.questions.8.label',
+    type: 'radio',
+    page: 4,
+    items: items['8'],
+    scale: [
       'measures.questions.8.options.disbelieveStrong',
       'measures.questions.8.options.disbelieveLittle',
       'measures.questions.8.options.neutral',
       'measures.questions.8.options.believeLittle',
       'measures.questions.8.options.believeStrong'
     ],
-    {labelTop: true}
-  ),
-  generateSchema(
-    'measures.questions.9.label',
-    'radio',
-      5,
-    items['9'],
-    NINE_POINT_SCALE,
-    {
-      labelTop: false,
-      labels: [{
-          rating: 0,
-          label: 'measures.questions.9.options.notAtAll'
+    options: {labelTop: true}
+  }),
+  generateSchema({
+    question:'measures.questions.9.label',
+    type: 'radio',
+    page: 5,
+    items: items['9'],
+    scale: NINE_POINT_SCALE,
+    options: {
+        labelTop: false,
+        labels: [{
+            rating: 0,
+            label: 'measures.questions.9.options.notAtAll'
         },
-        {
-          rating: 3,
-          label: 'measures.questions.9.options.aLittle'
-        },
-        {
-          rating: 5,
-          label: 'measures.questions.9.options.moderately'
-        },
-        {
-          rating: 7,
-          label: 'measures.questions.9.options.veryWell'
-        },
-        {
-          rating: 9,
-          label: 'measures.questions.9.options.exactly'
-        }]
+            {
+                rating: 3,
+                label: 'measures.questions.9.options.aLittle'
+            },
+            {
+                rating: 5,
+                label: 'measures.questions.9.options.moderately'
+            },
+            {
+                rating: 7,
+                label: 'measures.questions.9.options.veryWell'
+            },
+            {
+                rating: 9,
+                label: 'measures.questions.9.options.exactly'
+            }]
     }
-  ),
-  generateSchema(
-    'measures.questions.10.label',
-    'radio',
-      5,
-    items['10'],
-    [
+  }),
+  generateSchema({
+    question: 'measures.questions.10.label',
+    type: 'radio',
+    page: 5,
+    items: items['10'],
+    scale: [
       'measures.questions.10.options.disagreeStrongly',
       'measures.questions.10.options.disagree',
       'measures.questions.10.options.neutral',
       'measures.questions.10.options.agree',
       'measures.questions.10.options.agreeStrongly'
     ],
-    {labelTop: true}
-  ),
+    options: {labelTop: true}
+  }),
   {
     question: 'measures.questions.11.label',
     type: 'radio-input',
@@ -483,75 +481,75 @@ var questions = [
       }
     }
   },
-  generateSchema(
-    'measures.questions.13.label',
-    'radio',
-      6,
-    items['13'],
-    [
+  generateSchema({
+    question: 'measures.questions.13.label',
+    type: 'radio',
+    page: 6,
+    items: items['13'],
+    scale: [
       'measures.questions.13.options.disagreeStrongly',
       'measures.questions.13.options.disagree',
       'measures.questions.13.options.neutral',
       'measures.questions.13.options.agree',
       'measures.questions.13.options.agreeStrongly'
     ],
-    {labelTop: true}
-  ),
-  generateSchema(
-    'measures.questions.14.label',
-    'radio',
-      6,
-    items['14'],
-    [
+    options: {labelTop: true}
+  }),
+  generateSchema({
+    question: 'measures.questions.14.label',
+    type: 'radio',
+    page: 6,
+    items: items['14'],
+    scale: [
       'measures.questions.14.options.disagreeStrongly',
       'measures.questions.14.options.disagree',
       'measures.questions.14.options.neutral',
       'measures.questions.14.options.agree',
       'measures.questions.14.options.agreeStrongly'
     ],
-    {labelTop: true}
-  ),
-  generateSchema(
-    'measures.questions.15.label',
-    'radio',
-      6,
-    items['15'],
-    [
+    options: {labelTop: true}
+  }),
+  generateSchema({
+    question: 'measures.questions.15.label',
+    type: 'radio',
+    page: 6,
+    items: items['15'],
+    scale: [
       'measures.questions.15.options.disagreeStrongly',
       'measures.questions.15.options.disagree',
       'measures.questions.15.options.neutral',
       'measures.questions.15.options.agree',
       'measures.questions.15.options.agreeStrongly'
     ],
-    {labelTop: true}
-  ),
-  generateSchema(
-    'measures.questions.16.label',
-    'radio',
-      7,
-    items['16'],
-    [
+    options: {labelTop: true}
+  }),
+  generateSchema({
+    question: 'measures.questions.16.label',
+    type: 'radio',
+    page: 7,
+    items: items['16'],
+    scale: [
       'measures.questions.16.options.notAtAll',
       'measures.questions.16.options.aLittle',
       'measures.questions.16.options.quiteaBit',
       'measures.questions.16.options.completely'
     ],
-    {labelTop: true}
-  ),
-  generateSchema(
-    'measures.questions.17.label',
-    'radio',
-     7,
-    items['17'],
-    [
+    options: {labelTop: true}
+  }),
+  generateSchema({
+    question: 'measures.questions.17.label',
+    type: 'radio',
+    page: 7,
+    items: items['17'],
+    scale: [
       'measures.questions.17.options.disagreeStrongly',
       'measures.questions.17.options.disagree',
       'measures.questions.17.options.neutral',
       'measures.questions.17.options.agree',
       'measures.questions.17.options.agreeStrongly'
     ],
-    {labelTop: true}
-  )
+    options: {labelTop: true}
+  })
 ];
 
 const Validations = buildValidations(generateValidators(questions));

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -4,23 +4,23 @@ import layout from './template';
 import {validator, buildValidations} from 'ember-cp-validations';
 
 var items = {
-  '4': [
-      'measures.questions.4.items.1.label',
-      'measures.questions.4.items.2.label',
-      'measures.questions.4.items.3.label',
-      'measures.questions.4.items.4.label',
-      'measures.questions.4.items.5.label',
-      'measures.questions.4.items.6.label',
-      'measures.questions.4.items.7.label',
-      'measures.questions.4.items.8.label',
-      'measures.questions.4.items.9.label',
-      'measures.questions.4.items.10.label',
-      'measures.questions.4.items.11.label',
-      'measures.questions.4.items.12.label',
-      'measures.questions.4.items.13.label',
-      'measures.questions.4.items.14.label',
-      'measures.questions.4.items.15.label',
-      'measures.questions.4.items.16.label'
+  '3': [
+      'measures.questions.3.items.1.label',
+      'measures.questions.3.items.2.label',
+      'measures.questions.3.items.3.label',
+      'measures.questions.3.items.4.label',
+      'measures.questions.3.items.5.label',
+      'measures.questions.3.items.6.label',
+      'measures.questions.3.items.7.label',
+      'measures.questions.3.items.8.label',
+      'measures.questions.3.items.9.label',
+      'measures.questions.3.items.10.label',
+      'measures.questions.3.items.11.label',
+      'measures.questions.3.items.12.label',
+      'measures.questions.3.items.13.label',
+      'measures.questions.3.items.14.label',
+      'measures.questions.3.items.15.label',
+      'measures.questions.3.items.16.label'
   ],
   '5': [
       'measures.questions.5.items.1.label',
@@ -169,13 +169,13 @@ var items = {
       'measures.questions.16.items.4.label',
       'measures.questions.16.items.5.label'
   ],
-  '18': [
-      'measures.questions.18.items.1.label',
-      'measures.questions.18.items.2.label',
-      'measures.questions.18.items.3.label',
-      'measures.questions.18.items.4.label',
-      'measures.questions.18.items.5.label',
-      'measures.questions.18.items.6.label'
+  '17': [
+      'measures.questions.17.items.1.label',
+      'measures.questions.17.items.2.label',
+      'measures.questions.17.items.3.label',
+      'measures.questions.17.items.4.label',
+      'measures.questions.17.items.5.label',
+      'measures.questions.17.items.6.label'
   ]
 };
 
@@ -213,10 +213,11 @@ var generateValidators = function(questions) {
   return validators;
 };
 
-var generateSchema = function(question, type, items, scale, options) {
+var generateSchema = function(question, type, page, items, scale, options) {
   var schema = {
     question: question,
     type: type,
+    page: page,
     scale: scale,
     items: []
   };
@@ -237,6 +238,7 @@ var questions = [
   generateSchema(
     'measures.questions.1.label',
     'select',
+     1,
     [''],
     [
       'measures.questions.1.options.extremelyNeg',
@@ -253,6 +255,7 @@ var questions = [
   generateSchema(
     'measures.questions.2.label',
     'radio',
+      1,
     [''],
     SEVEN_POINT_SCALE,
     {
@@ -263,7 +266,7 @@ var questions = [
         },
         {
           rating: 2,
-          label: 'measures.questions.2.options.hardleyEver'
+          label: 'measures.questions.2.options.hardlyEver'
         },
         {
           rating: 4,
@@ -277,37 +280,20 @@ var questions = [
     }
   ),
   generateSchema(
-    'measures.questions.3.label',
+    'measures.questions.3.label.10am',
     'radio',
-    [''],
-    TEN_POINT_SCALE,
-    {
-      labelTop: false,
-      labels: [{
-          rating: 0,
-          label: 'measures.questions.3.options.unwilling'
-        },
-        {
-          rating: 10,
-          label: 'measures.questions.3.options.fullyPrepared'
-        }
-      ]
-    }
-  ),
-  generateSchema(
-    'measures.questions.4.label.10am',
-    'radio',
-    items['4'],
+      1,
+    items['3'],
     [
-      'measures.questions.4.options.extremelyChar',
-      'measures.questions.4.options.quiteUnchar',
-      'measures.questions.4.options.fairlyUnchar',
-      'measures.questions.4.options.somewhatUnchar',
-      'measures.questions.4.options.neutral',
-      'measures.questions.4.options.somewhatChar',
-      'measures.questions.4.options.fairlyChar',
-      'measures.questions.4.options.quiteChar',
-      'measures.questions.4.options.extremelyChar'
+      'measures.questions.3.options.extremelyChar',
+      'measures.questions.3.options.quiteUnchar',
+      'measures.questions.3.options.fairlyUnchar',
+      'measures.questions.3.options.somewhatUnchar',
+      'measures.questions.3.options.neutral',
+      'measures.questions.3.options.somewhatChar',
+      'measures.questions.3.options.fairlyChar',
+      'measures.questions.3.options.quiteChar',
+      'measures.questions.3.options.extremelyChar'
     ],
     {
         labelTop: true,
@@ -315,8 +301,28 @@ var questions = [
     }
   ),
   generateSchema(
+    'measures.questions.4.label',
+    'radio',
+      2,
+    [''],
+    TEN_POINT_SCALE,
+    {
+      labelTop: false,
+      labels: [{
+          rating: 0,
+          label: 'measures.questions.4.options.unwilling'
+        },
+        {
+          rating: 10,
+          label: 'measures.questions.4.options.fullyPrepared'
+        }
+      ]
+    }
+  ),
+  generateSchema(
     'measures.questions.5.label',
     'radio',
+      2,
     items['5'],
     [
       'measures.questions.5.options.disagreeStrongly',
@@ -330,6 +336,7 @@ var questions = [
   {
     question: 'measures.questions.6.label',
     type: 'radio',
+    page: 3,
     scale: SEVEN_POINT_SCALE,
     items: [
       {
@@ -391,6 +398,7 @@ var questions = [
   generateSchema(
     'measures.questions.7.label',
     'radio',
+      3,
     items['7'],
     [
       'measures.questions.7.options.disagreeStrongly',
@@ -404,6 +412,7 @@ var questions = [
   generateSchema(
     'measures.questions.8.label',
     'radio',
+      4,
     items['8'],
     [
       'measures.questions.8.options.disbelieveStrong',
@@ -417,6 +426,7 @@ var questions = [
   generateSchema(
     'measures.questions.9.label',
     'radio',
+      5,
     items['9'],
     NINE_POINT_SCALE,
     {
@@ -446,6 +456,7 @@ var questions = [
   generateSchema(
     'measures.questions.10.label',
     'radio',
+      5,
     items['10'],
     [
       'measures.questions.10.options.disagreeStrongly',
@@ -459,6 +470,7 @@ var questions = [
   {
     question: 'measures.questions.11.label',
     type: 'radio-input',
+    page: 5,
     scale: ['measures.questions.11.options.yes', 'measures.questions.11.options.no'],
     items: {
       radio: {
@@ -474,6 +486,7 @@ var questions = [
   generateSchema(
     'measures.questions.13.label',
     'radio',
+      6,
     items['13'],
     [
       'measures.questions.13.options.disagreeStrongly',
@@ -487,6 +500,7 @@ var questions = [
   generateSchema(
     'measures.questions.14.label',
     'radio',
+      6,
     items['14'],
     [
       'measures.questions.14.options.disagreeStrongly',
@@ -500,6 +514,7 @@ var questions = [
   generateSchema(
     'measures.questions.15.label',
     'radio',
+      6,
     items['15'],
     [
       'measures.questions.15.options.disagreeStrongly',
@@ -513,6 +528,7 @@ var questions = [
   generateSchema(
     'measures.questions.16.label',
     'radio',
+      7,
     items['16'],
     [
       'measures.questions.16.options.notAtAll',
@@ -522,25 +538,17 @@ var questions = [
     ],
     {labelTop: true}
   ),
-  {
-    question: 'measures.questions.17.label',
-    type: 'textarea',
-    items: {
-      input: {
-        value: null
-      }
-    }
-  },
   generateSchema(
-    'measures.questions.18.label',
+    'measures.questions.17.label',
     'radio',
-    items['18'],
+     7,
+    items['17'],
     [
-      'measures.questions.18.options.disagreeStrongly',
-      'measures.questions.18.options.disagree',
-      'measures.questions.18.options.neutral',
-      'measures.questions.18.options.agree',
-      'measures.questions.18.options.agreeStrongly'
+      'measures.questions.17.options.disagreeStrongly',
+      'measures.questions.17.options.disagree',
+      'measures.questions.17.options.neutral',
+      'measures.questions.17.options.agree',
+      'measures.questions.17.options.agreeStrongly'
     ],
     {labelTop: true}
   )
@@ -551,12 +559,17 @@ const Validations = buildValidations(generateValidators(questions));
 export default ExpFrameBaseComponent.extend(Validations, {
     type: 'exp-rating-form',
     layout: layout,
+    currentPage: 1,
+    totalPages: 7,
+    progressBarPage: Ember.computed('currentPage', function() {
+        return this.currentPage + 4;
+    }),
     questions: Ember.computed(function() {
         var condition = this.get('session').get('experimentCondition');
         if (condition === '7pm') {
-            questions[3]['question'] = 'measures.questions.4.label.7pm';
+            questions[2]['question'] = 'measures.questions.3.label.7pm';
         } else if (condition === '10am') {
-            questions[3]['question'] = 'measures.questions.4.label.10am';
+            questions[2]['question'] = 'measures.questions.3.label.10am';
         }
         return questions;
     }),
@@ -588,6 +601,11 @@ export default ExpFrameBaseComponent.extend(Validations, {
                 type: 'object'
               }
             }
+        }
+    },
+    actions: {
+        nextPage() {
+            this.set('currentPage', this.currentPage + 1);
         }
     }
 });

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -571,7 +571,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
         }
         return questions;
     }),
-    responses: Ember.computed('currentPage', function () {
+    responses: Ember.computed(function () {
         var questions = this.get('questions');
         var responses = {};
         for (var i = 0; i < questions.length; i++) {
@@ -582,7 +582,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
             }
         }
         return responses;
-    }),
+    }).volatile(),
     meta: {
         name: 'ExpRatingForm',
         description: 'TODO: a description of this frame goes here.',

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -221,11 +221,9 @@ var generateSchema = function (data) {
             description: data.items[i],
             value: null
         };
-        for (var option in options) {
-            if (options.hasOwnProperty(option)) {
-                ret[option] = options[option];
-            }
-        }
+        Object.keys(options).forEach(function(option) {
+            ret[option] = options[option];
+        });
         items.push(ret);
     }
     data['items'] = items;

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -1,9 +1,9 @@
 <div class="row">
   {{#bs-form}}
-  {{#each questions as |question|}}
+  {{#each questions as |question index|}}
     {{#if (eq question.page currentPage)}}
       {{#bs-form-group}}
-        <label class="break-line question-label">{{t question.question}}</label><br>
+        <label class="break-line question-label">{{add index 1}}. {{t question.question}}</label><br>
         {{#if (eq question.type 'radio')}}
           {{#each question.items as |item|}}
             {{#if item.description}}

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -23,8 +23,6 @@
             {{#input value=question.input.value}}{{/input}}
             <br>
           {{/if}}
-        {{else if (eq question.type 'textarea')}}
-          {{#textarea value=question.input.value cols="100" rows="6"}}{{/textarea}}
         {{/if}}
       {{/bs-form-group}}
     {{/if}}
@@ -33,7 +31,7 @@
 </div>
 <div class="row exp-controls">
   {{#if (eq currentPage totalPages)}}
-    <div class='btn btn-primary pull-right' {{action 'next'}}>Final{{t 'global.continueLabel'}}</div>
+    <div class='btn btn-primary pull-right' {{action 'next'}}>{{t 'global.continueLabel'}}</div>
   {{else}}
     <div class='btn btn-primary pull-right' {{action 'nextPage'}}>{{t 'global.continueLabel'}}</div>
   {{/if}}

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -1,20 +1,21 @@
 <div class="row">
   {{#bs-form}}
   {{#each questions as |question|}}
-    {{#bs-form-group}}
-      <label class="break-line question-label">{{t question.question}}</label><br>
-      {{#if (eq question.type 'radio')}}
-        {{#each question.items as |item|}}
-          {{#if item.description}}
-            <label>{{t item.description}}</label>
-          {{/if}}
-          {{radio-group options=question.scale labelTop=item.labelTop labels=item.labels formatLabel=item.formatLabel value=item.value}}
-          <br>
-          <br>
-        {{/each}}
-      {{else if (eq question.type 'select')}}
-        {{select-input options=question.scale value=question.items.0.value}}
-      {{else if (eq question.type 'radio-input')}}
+    {{#if (eq question.page currentPage)}}
+      {{#bs-form-group}}
+        <label class="break-line question-label">{{t question.question}}</label><br>
+        {{#if (eq question.type 'radio')}}
+          {{#each question.items as |item|}}
+            {{#if item.description}}
+              <label>{{t item.description}}</label>
+            {{/if}}
+            {{radio-group options=question.scale labelTop=item.labelTop labels=item.labels formatLabel=item.formatLabel value=item.value}}
+            <br>
+            <br>
+          {{/each}}
+        {{else if (eq question.type 'select')}}
+          {{select-input options=question.scale value=question.items.0.value}}
+        {{else if (eq question.type 'radio-input')}}
           {{radio-group options=question.scale value=question.items.radio.value}}
           <br>
           {{#if (eq question.items.radio.value 'measures.questions.11.options.yes')}}
@@ -22,15 +23,19 @@
             {{#input value=question.input.value}}{{/input}}
             <br>
           {{/if}}
-      {{else if (eq question.type 'textarea')}}
-        {{#textarea value=question.input.value cols="100" rows="6"}}{{/textarea}}
-      {{/if}}
-    {{/bs-form-group}}
-    <br>
+        {{else if (eq question.type 'textarea')}}
+          {{#textarea value=question.input.value cols="100" rows="6"}}{{/textarea}}
+        {{/if}}
+      {{/bs-form-group}}
+    {{/if}}
   {{/each}}
-{{/bs-form}}
+  {{/bs-form}}
 </div>
 <div class="row exp-controls">
-  <div class='btn btn-primary pull-right' {{action 'next'}}>{{t 'global.continueLabel'}}</div>
-  {{progress-bar pageNumber=5}}
+  {{#if (eq currentPage totalPages)}}
+    <div class='btn btn-primary pull-right' {{action 'next'}}>Final{{t 'global.continueLabel'}}</div>
+  {{else}}
+    <div class='btn btn-primary pull-right' {{action 'nextPage'}}>{{t 'global.continueLabel'}}</div>
+  {{/if}}
+  {{progress-bar pageNumber=progressBarPage}}
 </div>

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -16,11 +16,11 @@
         {{else if (eq question.type 'select')}}
           {{select-input options=question.scale value=question.items.0.value}}
         {{else if (eq question.type 'radio-input')}}
-          {{radio-group options=question.scale value=question.items.radio.value}}
+          {{radio-group options=question.scale value=question.items.0.value}}
           <br>
-          {{#if (eq question.items.radio.value 'measures.questions.11.options.yes')}}
-            <label>{{t question.items.input.description}}</label>
-            {{#input value=question.input.value}}{{/input}}
+          {{#if (eq question.items.0.value 'measures.questions.11.options.yes')}}
+            <label>{{t question.items.1.description}}</label>
+            {{#input value=question.items.1.value}}{{/input}}
             <br>
           {{/if}}
         {{/if}}

--- a/exp-player/addon/helpers/add.js
+++ b/exp-player/addon/helpers/add.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function add(params) {
+    return params[0] + params[1];
+}
+
+export default Ember.Helper.helper(add);

--- a/exp-player/app/helpers/add.js
+++ b/exp-player/app/helpers/add.js
@@ -1,0 +1,1 @@
+export { default, add } from 'exp-player/helpers/add';

--- a/exp-player/tests/unit/helpers/add-test.js
+++ b/exp-player/tests/unit/helpers/add-test.js
@@ -1,0 +1,10 @@
+import { add } from '../../../helpers/add';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | add');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = add([42]);
+  assert.ok(result);
+});


### PR DESCRIPTION
## Purpose
Make it easier for participants to take the survey by splitting up the rating-form into multiple pages.

## Summary of changes
- Add page to each question, and in the template only show the question if it's page equals the `currentPage`.
- Make `generateSchema` expect an object with parameters so that it is easier to tell what is getting passed in.

## Testing notes
Requires https://github.com/CenterForOpenScience/isp/pull/48 and https://github.com/CenterForOpenScience/isp/pull/49 to be merged

