### PR TITLE
Make exit and results url frame parameters

### DIFF
--- a/exp-player/addon/components/exp-thank-you/component.js
+++ b/exp-player/addon/components/exp-thank-you/component.js
@@ -10,7 +10,14 @@ export default ExpFrameBaseComponent.extend({
         parameters: {
             type: 'object',
             properties: {
-                // define parameters here
+                exitUrl: {
+                    type: 'string',
+                    default: 'exit'
+                },
+                resultsUrl: {
+                    type: 'string',
+                    default: 'participate.results'
+                }
             }
         },
         data: {

--- a/exp-player/addon/components/exp-thank-you/template.hbs
+++ b/exp-player/addon/components/exp-thank-you/template.hbs
@@ -4,11 +4,11 @@
 </div>
 <div class="row exp-controls">
     <div class="pull-right">
-        {{#link-to 'exit' class="btn btn-default pull-right"}}
+        {{#link-to exitUrl class="btn btn-default pull-right"}}
             {{t 'thankyou.exitButton'}}
         {{/link-to}}
         <br>
-        {{#link-to 'participate.results' class="btn btn-primary pull-right"}}
+        {{#link-to resultsUrl class="btn btn-primary pull-right"}}
             {{t 'thankyou.personalityFeedbackButton'}}
         {{/link-to}}
     </div>


### PR DESCRIPTION
## Purpose
Make it possible to pass in urls for the exit and results page, making it easier to change them if the routes change.

## Summary of changes
Specify the `exitUrl` and `resultsUrl` as parameters in the `exp-thank-you` component.