### PR TITLE
Scroll to top of next frame [LEI-185]

### DIFF
--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -123,6 +123,7 @@ export default Ember.Component.extend({
             this.send('setTimeEvent', 'nextFrame');
             this.send('save');
             this.sendAction('next');
+            window.scrollTo(0,0);
         },
         last() {
             this.sendAction('last');

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -606,6 +606,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
         nextPage() {
             this.set('currentPage', this.currentPage + 1);
             this.send('save');
+            window.scrollTo(0,0);
         }
     }
 });


### PR DESCRIPTION
## Purpose
Currently, when a user scrolls to the bottom of an exp-frame and hits continue, the scroll position remains the same in the next frame and the user must manually scroll to the top to view the beginning of the form.

## Summary of changes
When a user scrolls to the bottom of the page and hits continue to move on to the next frame, use `window.scrollTo(0,0)` so that the user sees the top of the frame first.