### PR TITLE
Hide optional overview form question [LEI-192] 

### DIFF
--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -117,7 +117,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
         responses[i] = questions[i].value;
       }
       return responses;
-    }),
+    }).volatile(),
     meta: {
       name: 'ExpOverview',
         description: 'TODO: a description of this frame goes here.',

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -107,13 +107,16 @@ export default ExpFrameBaseComponent.extend(Validations, {
     type: 'exp-overview',
     layout: layout,
     questions: questions,
-    responses: Ember.computed('questions', function() {
-        var questions = this.get('questions');
-        var responses = {};
-        for (var i=0; i < questions.length; i++) {
-            responses[i] = questions[i].value;
-        }
-        return responses;
+    showOptional: Ember.computed('questions.7.value', function() {
+       return this.questions[7].value === 'global.yesLabel';
+    }),
+    responses: Ember.computed(function() {
+      var questions = this.get('questions');
+      var responses = {};
+      for (var i=0; i < questions.length; i++) {
+        responses[i] = questions[i].value;
+      }
+      return responses;
     }),
     meta: {
       name: 'ExpOverview',

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -3,14 +3,19 @@
     {{#bs-form}}
       {{#each questions as |question|}}
         {{#bs-form-group}}
-          <label>{{t question.question}}</label>
-          {{#if (eq question.type 'radio')}}
-            {{isp-radio-group options=question.scale labelTop=question.labelTop value=question.value}}
-          {{else if (eq question.type 'select')}}
-            {{select-input options=question.scale value=question.value}}
-          {{else if (eq question.type 'input')}}
-            {{#input class="form-control auto-width" value=question.value}}{{/input}}
-          {{/if}}
+          {{#unless question.optional}}
+            <label>{{t question.question}}</label>
+            {{#if (eq question.type 'radio')}}
+              {{isp-radio-group options=question.scale labelTop=question.labelTop value=question.value}}
+            {{else if (eq question.type 'select')}}
+              {{select-input options=question.scale value=question.value}}
+            {{else if (eq question.type 'input')}}
+              {{#input class="form-control auto-width" value=question.value}}{{/input}}
+            {{/if}}
+          {{else if showOptional}}
+            <label>{{t question.question}}</label>
+            {{#input value=question.value}}{{/input}}
+          {{/unless}}
         {{/bs-form-group}}
       {{/each}}
       {{progress-bar pageNumber=1}}


### PR DESCRIPTION
Purpose
-------
On the exp-overview form, if a user answers yes to question 8: "Do you follow a religion"
show question 9: "If so, which one do you follow?" Otherwise, hide it.

Changes
-------
Add a computed property `showOptional` that watches the value of question 8. Then in the template, only show that question if `showOptional` is true.