### PR TITLE
Mark session as completed

### DIFF
--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -607,6 +607,10 @@ export default ExpFrameBaseComponent.extend(Validations, {
             this.set('currentPage', this.currentPage + 1);
             this.send('save');
             window.scrollTo(0,0);
+        },
+        continue() {
+            this.sendAction('sessionCompleted');
+            this.send('next');
         }
     }
 });

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -31,7 +31,7 @@
 </div>
 <div class="row exp-controls">
   {{#if (eq currentPage totalPages)}}
-    <div class='btn btn-primary pull-right' {{action 'next'}}>{{t 'global.continueLabel'}}</div>
+    <div class='btn btn-primary pull-right' {{action 'continue'}}>{{t 'global.continueLabel'}}</div>
   {{else}}
     <div class='btn btn-primary pull-right' {{action 'nextPage'}}>{{t 'global.continueLabel'}}</div>
   {{/if}}


### PR DESCRIPTION
## Purpose
In order for experiment data to show up in experimenter, the session must get marked as completed. 

## Changes
Mark the session as completed after the user finishes the last survey page.
