### PR TITLE
Fix getting past sessions from profileId

### DIFF
--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -47,9 +47,8 @@ export default DS.Model.extend(JamModel, {
         return profiles.filter(getProfile)[0];
     },
     pastSessionsFor(experiment, profile) {
-        var profileId = Ember.get(profile, 'id') || '*';
-        return this.get('store').query(experiment.get('sessionCollectionId'), {
-            'filter[profileId]': profileId
-        });
+        var profileId = Ember.get(profile, 'profileId');
+        var query = profileId ? { 'filter[profileId]': profileId } : {};
+        return this.get('store').query(experiment.get('sessionCollectionId'), query);
     }
 });


### PR DESCRIPTION
## Purpose
Fix getting past sessions

## Change
- Filter sessions by `profile.profileId`, instead of `profile.id`
- If profileId is undefined, remove the query parameter instead of filtering by `*`