### PR TITLE
Fix radio button spacing in measure 6, item 1 [LEI-195]

### DIFF
--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -342,6 +342,7 @@ var questions = [
                 description: 'measures.questions.6.items.1.label',
                 value: null,
                 labelTop: false,
+                formatLabel: 'label-spacing',
                 labels: [{
                     rating: 0,
                     label: 'measures.questions.6.items.1.options.notHappy'


### PR DESCRIPTION
## Purpose
The first and last radio buttons in measure 6, item 1 were spaced further away from the rest:  
![screen shot 2016-09-13 at 2 50 24 pm](https://cloud.githubusercontent.com/assets/6414394/18487009/861457a4-79c1-11e6-87df-d6f8dbaf79c6.png)


## Summary of changes
Even out the spacing between the radio buttons by setting a max-width:  
![screen shot 2016-09-13 at 2 46 54 pm](https://cloud.githubusercontent.com/assets/6414394/18487022/9716627c-79c1-11e6-86f5-b42b6d3f235a.png)
