### PR TITLE
Feature: De-serialize form data [LEI-194]

### DIFF
--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -152,14 +152,12 @@ export default ExpFrameBaseComponent.extend({
                   responses['cardSort1'][name] = category.cards.map((cardItem) => cardItem.id);
               }
           }
-          if (this.get('cardSortResponse2')) {
-              cardSortResponse = this.get('cardSortResponse2');
-              // Assumption: this unpacks a list of { categories: {name: name, cards: [cards]} } objects
-              for (let categorySet of cardSortResponse) {
-                  for (let category of categorySet.categories) {
-                      let name = category.name.split('.').pop();
-                      responses['cardSort2'][name] = category.cards.map((cardItem) => cardItem.id);
-                  }
+          cardSortResponse = this.get('buckets2');
+          // Assumption: this unpacks a list of { categories: {name: name, cards: [cards]} } objects
+          for (let categorySet of cardSortResponse) {
+              for (let category of categorySet.categories) {
+                  let name = category.name.split('.').pop();
+                  responses['cardSort2'][name] = category.cards.map((cardItem) => cardItem.id);
               }
           }
           return responses;
@@ -227,7 +225,6 @@ export default ExpFrameBaseComponent.extend({
       window.scrollTo(0,0);
     },
     continue() {
-      this.set('cardSortResponse2', this.buckets2);
       this.send('next');
     }
   },

--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -134,20 +134,36 @@ export default ExpFrameBaseComponent.extend({
   }),
 
   // Represent the sorted cards in a human-readable format for storage in the database
-  responses: Ember.computed('cardSortResponse', function () {
-      let cardSortResponse = this.get('cardSortResponse');
-
-      // Final data should be returned as object {categoryName: [cardIdentifiers] }
-      let responses = {};
-
-      // Assumption: this unpacks a list of { categories: {name: name, cards: [cards]} } objects
-      for (let categorySet of cardSortResponse) {
-          for (let category of categorySet.categories) {
-              let name = category.name.split('.').pop();
-              responses[name] = category.cards.map((cardItem) => cardItem.id);
+  responses: Ember.computed('cardSortResponse', 'cardSortResponse2', {
+      get(key) {
+          // Final data for each card-sort should be returned as object {categoryName: [cardIdentifiers] }
+          let responses = {
+              cardSort1: {},
+              cardSort2: {}
+          };
+          let cardSortResponse;
+          if (this.get('cardSortResponse')) {
+              cardSortResponse = this.get('cardSortResponse');
+              for (let category of cardSortResponse) {
+                  let name = category.name.split('.').pop();
+                  responses['cardSort1'][name] = category.cards.map((cardItem) => cardItem.id);
+              }
           }
+          if (this.get('cardSortResponse2')) {
+              cardSortResponse = this.get('cardSortResponse2');
+              // Assumption: this unpacks a list of { categories: {name: name, cards: [cards]} } objects
+              for (let categorySet of cardSortResponse) {
+                  for (let category of categorySet.categories) {
+                      let name = category.name.split('.').pop();
+                      responses['cardSort2'][name] = category.cards.map((cardItem) => cardItem.id);
+                  }
+              }
+          }
+          return responses;
+      },
+      set(key, value) {
+          return value;
       }
-      return responses;
   }),
 
   isValid: Ember.computed(
@@ -202,12 +218,14 @@ export default ExpFrameBaseComponent.extend({
       target.unshiftObject(card);
     },
     nextPage() {
+      this.set('cardSortResponse', Ember.copy(this.buckets, true));
+      this.send('save');
       this.set('page', 'cardSort2');
       this.sendAction('updateFramePage', 1);
       window.scrollTo(0,0);
     },
     continue() {
-      this.set('cardSortResponse', this.buckets2);
+      this.set('cardSortResponse2', this.buckets2);
       this.send('next');
     }
   },
@@ -303,35 +321,49 @@ export default ExpFrameBaseComponent.extend({
           responses: {
               type: 'object',
               properties: {
-                  extremelyUnchar: {
-                      type: 'array'
+                  cardSort1: {
+                      uncharacteristic: {
+                          type: 'array'
+                      },
+                      neutral: {
+                          type: 'array'
+                      },
+                      characteristic: {
+                          type: 'array'
+                      }
+
                   },
-                  quiteUnchar: {
-                      type: 'array'
-                  },
-                  fairlyUnchar: {
-                      type: 'array'
-                  },
-                  somewhatUnchar: {
-                      type: 'array'
-                  },
-                  neutral: {
-                      type: 'array'
-                  },
-                  somewhatChar: {
-                      type: 'array'
-                  },
-                  fairlyChar: {
-                      type: 'array'
-                  },
-                  quiteChar: {
-                      type: 'array'
-                  },
-                  extremelyChar: {
-                      type: 'array'
+                  cardSort2: {
+                      extremelyUnchar: {
+                          type: 'array'
+                      },
+                      quiteUnchar: {
+                          type: 'array'
+                      },
+                      fairlyUnchar: {
+                          type: 'array'
+                      },
+                      somewhatUnchar: {
+                          type: 'array'
+                      },
+                      neutral: {
+                          type: 'array'
+                      },
+                      somewhatChar: {
+                          type: 'array'
+                      },
+                      fairlyChar: {
+                          type: 'array'
+                      },
+                      quiteChar: {
+                          type: 'array'
+                      },
+                      extremelyChar: {
+                          type: 'array'
+                      }
                   }
               }
-          },
+          }
       }
     }
   }

--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -136,7 +136,10 @@ export default ExpFrameBaseComponent.extend({
   // Represent the sorted cards in a human-readable format for storage in the database
   responses: Ember.computed('cardSortResponse', 'cardSortResponse2', {
       get(key) {
-          // Final data for each card-sort should be returned as object {categoryName: [cardIdentifiers] }
+          // Final data should be returned as {
+          //    cardSort1: object {categoryName: [cardIdentifiers] }
+          //    cardSort2: object {categoryName: [cardIdentifiers] }
+          // }
           let responses = {
               cardSort1: {},
               cardSort2: {}

--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -134,7 +134,7 @@ export default ExpFrameBaseComponent.extend({
   }),
 
   // Represent the sorted cards in a human-readable format for storage in the database
-  responses: Ember.computed('cardSortResponse', 'cardSortResponse2', {
+  responses: Ember.computed({
       get(key) {
           // Final data should be returned as {
           //    cardSort1: object {categoryName: [cardIdentifiers] }
@@ -167,8 +167,7 @@ export default ExpFrameBaseComponent.extend({
       set(key, value) {
           return value;
       }
-  }),
-
+  }).volatile(),
   isValid: Ember.computed(
     'buckets2.0.categories.0.cards.[]',
     'buckets2.0.categories.1.cards.[]',
@@ -221,7 +220,7 @@ export default ExpFrameBaseComponent.extend({
       target.unshiftObject(card);
     },
     nextPage() {
-      this.set('cardSortResponse', Ember.copy(this.buckets, true));
+      this.set('cardSortResponse', Ember.copy(this.get('buckets'), true));
       this.send('save');
       this.set('page', 'cardSort2');
       this.sendAction('updateFramePage', 1);

--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -51,7 +51,7 @@ export default Ember.Component.extend({
         var oldAttrs = options.oldAttrs || {};
 
         let clean = Ember.get(newAttrs, 'frameIndex.value') !== Ember.get(oldAttrs, 'frameIndex.value');
-        var defaultParams = this.setupParams(null, clean);
+        var defaultParams = this.setupParams(clean);
         if (clean) {
             Object.keys(defaultParams).forEach((key) => {
                 this.set(key, defaultParams[key]);
@@ -64,9 +64,9 @@ export default Ember.Component.extend({
             this.set('id', `${kind}-${frameIndex}`);
         }
     },
-    setupParams(params, clean) {
+    setupParams(clean) {
         // Add config properties and data to be serialized as instance parameters (overriding with values explicitly passed in)
-        params = params || this.get('frameConfig');
+       var params = this.get('frameConfig');
 
         var defaultParams = {};
         Object.keys(this.get('meta.parameters').properties || {}).forEach((key) => {
@@ -74,9 +74,6 @@ export default Ember.Component.extend({
         });
 
         Object.keys(this.get('meta.data').properties || {}).forEach((key) => {
-            if (this[key] && this[key].isDescriptor) {
-                return;
-            }
             var value = !clean ? this.get(key) : undefined;
             if (typeof value === 'undefined') {
                 // Make deep copy of the default value (to avoid subtle reference errors from reusing mutable containers)

--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -1,5 +1,6 @@
 // app/components/exp-frame-base.js
 import Ember from 'ember';
+import config from 'ember-get-config';
 
 export default Ember.Component.extend({
     /** An abstract component for defining experimenter frames
@@ -68,11 +69,13 @@ export default Ember.Component.extend({
             this.set('id', `${kind}-${frameIndex}`);
         }
 
-        var session = this.get('session');
-        var expData = session ? session.get('expData') : null;
-        if (session && session.get('expData')) {
-            var key = this.get('frameIndex') + '-' + this.get('id');
-            this.loadData(expData[key]);
+        if (config.loadData) {
+            var session = this.get('session');
+            var expData = session ? session.get('expData') : null;
+            if (session && session.get('expData')) {
+                var key = this.get('frameIndex') + '-' + this.get('id');
+                this.loadData(expData[key]);
+            }
         }
     },
     setupParams(clean) {

--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -40,6 +40,10 @@ export default Ember.Component.extend({
         this.set('eventTimings', []);
     }.on("init"),
 
+    loadData: function(frameData) {
+        return null;
+    },
+
     didReceiveAttrs: function(options) {
         this._super(...arguments);
 
@@ -63,6 +67,13 @@ export default Ember.Component.extend({
             var kind = this.get('kind');
             this.set('id', `${kind}-${frameIndex}`);
         }
+
+        var session = this.get('session');
+        var expData = session ? session.get('expData') : null;
+        if (session && session.get('expData')) {
+            var key = this.get('frameIndex') + '-' + this.get('id');
+            this.loadData(expData[key]);
+        }
     },
     setupParams(clean) {
         // Add config properties and data to be serialized as instance parameters (overriding with values explicitly passed in)
@@ -74,6 +85,9 @@ export default Ember.Component.extend({
         });
 
         Object.keys(this.get('meta.data').properties || {}).forEach((key) => {
+            if (this[key] && this[key].isDescriptor) {
+                return;
+            }
             var value = !clean ? this.get(key) : undefined;
             if (typeof value === 'undefined') {
                 // Make deep copy of the default value (to avoid subtle reference errors from reusing mutable containers)

--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -105,5 +105,11 @@ export default ExpFrameBaseComponent.extend(Validations, {
         continue() {
             this.send('next');
         }
+    },
+    loadData: function(frameData) {
+        var responses = frameData.responses;
+        this.set('q1', responses.q1);
+        this.set('q2', responses.q2);
+        this.set('q3', responses.q3);
     }
 });

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -110,13 +110,21 @@ export default ExpFrameBaseComponent.extend(Validations, {
     showOptional: Ember.computed('questions.7.value', function() {
        return this.questions[7].value === 'global.yesLabel';
     }),
-    responses: Ember.computed(function() {
-      var questions = this.get('questions');
-      var responses = {};
-      for (var i=0; i < questions.length; i++) {
-        responses[i] = questions[i].value;
-      }
-      return responses;
+    responses: Ember.computed({
+      get(key) {
+        var questions = this.get('questions');
+        var responses = {};
+        for (var i=0; i < questions.length; i++) {
+          responses[i] = questions[i].value;
+        }
+        return responses;
+        },
+        set(key, value) {
+          for (var q=0; q < this.get('questions').length; q++) {
+            this.get('questions')[q].value = value[q];
+          }
+          return value;
+        }
     }).volatile(),
     meta: {
       name: 'ExpOverview',

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -111,19 +111,19 @@ export default ExpFrameBaseComponent.extend(Validations, {
        return this.questions[7].value === 'global.yesLabel';
     }),
     responses: Ember.computed({
-      get(key) {
-        var questions = this.get('questions');
-        var responses = {};
-        for (var i=0; i < questions.length; i++) {
-          responses[i] = questions[i].value;
-        }
-        return responses;
+        get(key) {
+            var questions = this.get('questions');
+            var responses = {};
+            for (var i=0; i < questions.length; i++) {
+                responses[i] = questions[i].value;
+            }
+            return responses;
         },
         set(key, value) {
-          for (var q=0; q < this.get('questions').length; q++) {
-            this.get('questions')[q].value = value[q];
-          }
-          return value;
+            for (var q=0; q < this.get('questions').length; q++) {
+                this.get('questions')[q].value = value[q];
+            }
+            return value;
         }
     }).volatile(),
     meta: {

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -111,21 +111,13 @@ export default ExpFrameBaseComponent.extend(Validations, {
     showOptional: Ember.computed('questions.7.value', function() {
        return this.questions[7].value === 'global.yesLabel';
     }),
-    responses: Ember.computed({
-        get(key) {
-            var questions = this.get('questions');
-            var responses = {};
-            for (var i=0; i < questions.length; i++) {
-                responses[i] = questions[i].value;
-            }
-            return responses;
-        },
-        set(key, value) {
-            for (var q=0; q < this.get('questions').length; q++) {
-                this.get('questions')[q].value = value[q];
-            }
-            return value;
+    responses: Ember.computed(function() {
+        var questions = this.get('questions');
+        var responses = {};
+        for (var i=0; i < questions.length; i++) {
+            responses[i] = questions[i].value;
         }
+        return responses;
     }).volatile(),
     meta: {
         name: 'ExpOverview',
@@ -179,10 +171,14 @@ export default ExpFrameBaseComponent.extend(Validations, {
                 }
             }
     },
-
     actions: {
       continue() {
           this.send('next');
       }
+    },
+    loadData: function(frameData) {
+        for (var q=0; q < this.get('questions').length; q++) {
+            this.get('questions')[q].value = frameData.responses[q];
+        }
     }
 });

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -91,7 +91,16 @@ able to continue the study.
     currentFrameConfig: Ember.computed('frames', 'frameIndex', function() {
         var frames = this.get('frames') || [];
         var frameIndex = this.get('frameIndex');
-        return frames[frameIndex];
+        var config = frames[frameIndex];
+        var session = this.get('session');
+        if (session && session.get('expData')) {
+            var key = frameIndex + '-' + frames[frameIndex]['id'];
+            if (session.get('expData')[key]) {
+                var data = session.get('expData')[key];
+                Ember.merge(config, data);
+            }
+        }
+        return config;
     }),
 
     _currentFrameTemplate: null,

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -91,16 +91,7 @@ able to continue the study.
     currentFrameConfig: Ember.computed('frames', 'frameIndex', function() {
         var frames = this.get('frames') || [];
         var frameIndex = this.get('frameIndex');
-        var config = frames[frameIndex];
-        var session = this.get('session');
-        if (session && session.get('expData')) {
-            var key = frameIndex + '-' + frames[frameIndex]['id'];
-            if (session.get('expData')[key]) {
-                var data = session.get('expData')[key];
-                Ember.merge(config, data);
-            }
-        }
-        return config;
+        return frames[frameIndex];
     }),
 
     _currentFrameTemplate: null,

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -573,17 +573,28 @@ export default ExpFrameBaseComponent.extend(Validations, {
         }
         return questions;
     }),
-    responses: Ember.computed(function () {
-        var questions = this.get('questions');
-        var responses = {};
-        for (var i = 0; i < questions.length; i++) {
-            var question = questions[i];
-            responses[i] = {};
-            for (var j = 0; j < question.items.length; j++) {
-                responses[i][j] = question.items[j].value;
+    responses: Ember.computed({
+        get(key) {
+            var questions = this.get('questions');
+            var responses = {};
+            for (var i = 0; i < questions.length; i++) {
+                var question = questions[i];
+                responses[i] = {};
+                for (var j = 0; j < question.items.length; j++) {
+                    responses[i][j] = question.items[j].value;
+                }
             }
+            return responses;
+        },
+        set(key, value) {
+            for (var i = 0; i < questions.length; i++) {
+                var question = questions[i];
+                for (var j = 0; j < question.items.length; j++) {
+                    question.items[j].value = value[i][j];
+                }
+            }
+            return value;
         }
-        return responses;
     }).volatile(),
     meta: {
         name: 'ExpRatingForm',

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -580,28 +580,17 @@ export default ExpFrameBaseComponent.extend(Validations, {
         }
         return questions;
     }),
-    responses: Ember.computed({
-        get(key) {
-            var questions = this.get('questions');
-            var responses = {};
-            for (var i = 0; i < questions.length; i++) {
-                var question = questions[i];
-                responses[i] = {};
-                for (var j = 0; j < question.items.length; j++) {
-                    responses[i][j] = question.items[j].value;
-                }
+    responses: Ember.computed(function() {
+        var questions = this.get('questions');
+        var responses = {};
+        for (var i = 0; i < questions.length; i++) {
+            var question = questions[i];
+            responses[i] = {};
+            for (var j = 0; j < question.items.length; j++) {
+                responses[i][j] = question.items[j].value;
             }
-            return responses;
-        },
-        set(key, value) {
-            for (var i = 0; i < questions.length; i++) {
-                var question = questions[i];
-                for (var j = 0; j < question.items.length; j++) {
-                    question.items[j].value = value[i][j];
-                }
-            }
-            return value;
         }
+        return responses;
     }).volatile(),
     meta: {
         name: 'ExpRatingForm',
@@ -639,6 +628,15 @@ export default ExpFrameBaseComponent.extend(Validations, {
         continue() {
             this.sendAction('sessionCompleted');
             this.send('next');
+        }
+    },
+    loadData: function(frameData) {
+        var questions = this.get('questions');
+        for (var i = 0; i < questions.length; i++) {
+            var question = questions[i];
+            for (var j = 0; j < question.items.length; j++) {
+                question.items[j].value = frameData.responses[i][j];
+            }
         }
     }
 });


### PR DESCRIPTION
## Purpose
If a user stops the survey mid-way and logs in again to finish, they should see their answers from before.

## Summary of changes
- Include session.expData in `currentFrameConfig` (which gets included with the default params passed to the exp-frame)
- Pass computed properties into the exp-frame
- Define a setter for the `responses` computed property of the `exp-overview` and `exp-rating-form` frames so that the questions are updated with the passed in data.
- Add a flag `loadData` to easily enable/disable loading existing data (Requires https://github.com/CenterForOpenScience/isp/pull/66 to get merged) 

## Note
Holding off on defining a setter for the `exp-card-sort` `responses` computed until https://github.com/CenterForOpenScience/exp-addons/pull/131 is merged 