### PR TITLE
Use translation string for "Previous Page"

### DIFF
--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -79,7 +79,7 @@
 <div class="row exp-controls">
     {{#if (eq page 'cardSort1')}}
       <div class="btn btn-default" {{ action 'previous' }}>
-        Previous Page
+        {{t 'global.previousLabel'}}
       </div>
       <div class="btn btn-primary pull-right" {{action "nextPage"}}>{{t 'global.continueLabel'}}</div>
       {{progress-bar pageNumber=3}}

--- a/exp-player/addon/components/exp-free-response/template.hbs
+++ b/exp-player/addon/components/exp-free-response/template.hbs
@@ -21,7 +21,7 @@
 </div>
 <div class="row exp-controls">
     <button class="btn btn-default" {{ action 'previous' }}>
-        Previous Page
+        {{t 'global.previousLabel'}}
     </button>
     <button class="btn btn-primary pull-right" {{ action 'continue' }}>
         {{t 'global.continueLabel'}}

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -36,7 +36,7 @@
     <div class='btn btn-primary pull-right' {{action 'nextPage'}}>{{t 'global.continueLabel'}}</div>
   {{/if}}
   {{#unless (eq framePage 0)}}
-    <div class="btn btn-default" {{ action 'previousPage' }}>Previous Page</div>
+    <div class="btn btn-default" {{ action 'previousPage' }}>{{t 'global.previousLabel'}}</div>
   {{/unless}}
   {{progress-bar pageNumber=progressBarPage}}
 </div>


### PR DESCRIPTION
Use translation string `'global.previousLabel'` for "Previous Page" button label so that it will get translated if the selected language changes.


