### PR TITLE
Fix showing optional questions

### DIFF
--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -109,7 +109,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
     questions: questions,
 
     showOptional: Ember.computed('questions.7.value', function() {
-       return this.questions[7].value === 'global.yesLabel';
+       return this.questions[7].value === 'yesLabel';
     }),
     responses: Ember.computed(function() {
         var questions = this.get('questions');

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -18,7 +18,7 @@
         {{else if (eq question.type 'radio-input')}}
           {{isp-radio-group options=question.scale value=question.items.0.value}}
           <br>
-          {{#if (eq question.items.0.value 'measures.questions.11.options.yes')}}
+          {{#if (eq question.items.0.value 'yes')}}
             <label>{{t question.items.1.description}}</label>
             {{#input value=question.items.1.value}}{{/input}}
             <br>


### PR DESCRIPTION
Fix showing optional questions on the exp-overview and exp-rating-form frames.

