### PR TITLE
Move progress bar below previous/continue buttons [LEI-223]

### DIFF
--- a/exp-player/addon/components/exp-free-response/template.hbs
+++ b/exp-player/addon/components/exp-free-response/template.hbs
@@ -16,7 +16,6 @@
       {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=q3}}{{/textarea}}
       <p class="text-muted">{{diff3}}</p>
     {{/bs-form-group}}
-    {{progress-bar pageNumber=2}}
   {{/bs-form}}
 </div>
 <div class="row exp-controls">
@@ -26,4 +25,5 @@
     <button class="btn btn-primary pull-right {{if (v-get this 'isInvalid') "disabled"}}" {{ action 'continue' }}>
         {{t 'global.continueLabel'}}
     </button>
+    {{progress-bar pageNumber=2}}
 </div>

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -18,9 +18,9 @@
           {{/unless}}
         {{/bs-form-group}}
       {{/each}}
-      {{progress-bar pageNumber=1}}
     {{/bs-form}}
 </div>
 <div class="row exp-controls">
     <button class="btn btn-primary pull-right {{if (v-get this 'isInvalid') "disabled"}}" {{ action 'continue' }}>{{t 'global.continueLabel'}}</button>
+    {{progress-bar pageNumber=1}}
 </div>


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-223

## Purpose
Ensure progress bars placement is consistent across forms

## Changes
On the overview and free-response forms, move the progress bar below the previous/continue buttons.

