### PR TITLE
Consolidate nextPage and continue actions [LEI-222]

### DIFF
--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -619,15 +619,6 @@ export default ExpFrameBaseComponent.extend(Validations, {
         }
     },
     actions: {
-        nextPage() {
-            if (this.get('validations.isValid')) {
-                this.send('save');
-                var page = this.get('framePage') + 1;
-                this.set('framePage', page);
-                this.sendAction('updateFramePage', page);
-                window.scrollTo(0, 0);
-            }
-        },
         previousPage() {
             var page = Math.max(0, this.get('framePage') - 1);
             this.set('framePage', page);
@@ -636,8 +627,16 @@ export default ExpFrameBaseComponent.extend(Validations, {
         },
         continue() {
             if (this.get('validations.isValid')) {
-                this.sendAction('sessionCompleted');
-                this.send('next');
+                if (this.get('framePage') !== this.get('lastPage')) {
+                    this.send('save');
+                    var page = this.get('framePage') + 1;
+                    this.set('framePage', page);
+                    this.sendAction('updateFramePage', page);
+                    window.scrollTo(0, 0);
+                } else {
+                    this.sendAction('sessionCompleted');
+                    this.send('next');
+                }
             }
         }
     },

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -30,11 +30,7 @@
   {{/bs-form}}
 </div>
 <div class="row exp-controls">
-  {{#if (eq framePage lastPage)}}
-    <div class='btn btn-primary pull-right {{if (v-get this 'isInvalid') "disabled"}}' {{action 'continue'}}>{{t 'global.continueLabel'}}</div>
-  {{else}}
-    <div class='btn btn-primary pull-right {{if (v-get this 'isInvalid') "disabled"}}' {{action 'nextPage'}}>{{t 'global.continueLabel'}}</div>
-  {{/if}}
+  <div class='btn btn-primary pull-right {{if (v-get this 'isInvalid') "disabled"}}' {{action 'continue'}}>{{t 'global.continueLabel'}}</div>
   {{#unless (eq framePage 0)}}
     <div class="btn btn-default" {{ action 'previousPage' }}>{{t 'global.previousLabel'}}</div>
   {{/unless}}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-222

## Purpose
On the `exp-rating-form`, consolidate `nextPage` and `continue` actions to reduce repetition in the template.
