### PR TITLE
Temporarily remove qsort validation

### DIFF
--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -220,18 +220,20 @@ export default ExpFrameBaseComponent.extend({
             target.unshiftObject(card);
         },
         nextPage() {
-            if (this.get('cards').length === 0) {
-                this.set('cardSortResponse', Ember.copy(this.get('buckets'), true));
-                this.send('save');
-                this.set('page', 'cardSort2');
-                this.sendAction('updateFramePage', 1);
-                window.scrollTo(0, 0);
-            }
+            //TODO: uncomment after UI testing
+            //if (this.get('cards').length === 0) {
+            this.set('cardSortResponse', Ember.copy(this.get('buckets'), true));
+            this.send('save');
+            this.set('page', 'cardSort2');
+            this.sendAction('updateFramePage', 1);
+            window.scrollTo(0, 0);
+            //}
         },
         continue() {
-            if (this.get('isValid')) {
-                this.send('next');
-            }
+            //TODO: uncomment after UI testing
+            //if (this.get('isValid')) {
+            this.send('next');
+            //}
         }
     },
 

--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -81,10 +81,10 @@
       <div class="btn btn-default" {{ action 'previous' }}>
         {{t 'global.previousLabel'}}
       </div>
-      <div class="btn btn-primary pull-right {{if (gt cards.length 0) 'disabled'}}" {{action "nextPage"}}>{{t 'global.continueLabel'}}</div>
+      <div class="btn btn-primary pull-right" {{action "nextPage"}}>{{t 'global.continueLabel'}}</div>
       {{progress-bar pageNumber=3}}
     {{else if (eq page 'cardSort2')}}
-      <div class="btn btn-primary pull-right {{if isValid 'enabled' 'disabled'}}" {{ action 'continue' }}>{{t 'global.continueLabel'}}</div>
+      <div class="btn btn-primary pull-right" {{ action 'continue' }}>{{t 'global.continueLabel'}}</div>
       {{progress-bar pageNumber=4}}
     {{/if}}
 </div>


### PR DESCRIPTION
Remove qsort validation to facilitate UI testing. TODO: Add a flag to make it easier to turn validation on or off.