### PR TITLE
Change username to computed property

### DIFF
--- a/exp-models/addon/adapters/application.js
+++ b/exp-models/addon/adapters/application.js
@@ -6,17 +6,17 @@ import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, UrlTemplates, {
     namespaceConfig: Ember.inject.service(),
-    authorizer: Ember.computed(function() {
-	return `authorizer:${this.get('namespaceConfig').get('authorizer')}`;
+    authorizer: Ember.computed(function () {
+        return `authorizer:${this.get('namespaceConfig').get('authorizer')}`;
     }),
-    host: Ember.computed(function() {
-	return this.get('namespaceConfig').get('url');
+    host: Ember.computed(function () {
+        return this.get('namespaceConfig').get('url');
     }),
     namespace: 'v1/id',
 
     urlSegments: {  // Make available to all adapters, not just documents. This appears to be extended rather than overwritten by children.
-        namespaceId: function() {
-	    return this.get('namespaceConfig').get('namespace');
-	}
+        namespaceId: function () {
+            return this.get('namespaceConfig').get('namespace');
+        }
     }
 });

--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -1,5 +1,5 @@
 /*
-Manage data about one or more documents in the accounts collection
+ Manage data about one or more documents in the accounts collection
  */
 import Ember from 'ember';
 import DS from 'ember-data';
@@ -11,14 +11,13 @@ function makeId() {
     var text = "";
     var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-    for( var i=0; i < 5; i++ ) {
+    for (var i = 0; i < 5; i++) {
         text += possible.charAt(Math.floor(Math.random() * possible.length));
     }
     return text;
 }
 
 export default DS.Model.extend(JamModel, {
-    username: DS.attr('string'),
     name: DS.attr('string'),
     password: DS.attr('string'),
     profiles: DS.attr('profiles'),
@@ -29,7 +28,13 @@ export default DS.Model.extend(JamModel, {
     history: DS.hasMany('history'),
     extra: DS.attr(),
 
-    generateProfileId: function() {
+    // Username should be immutable, and calculated from the last portion of the record ID
+    username: Ember.computed('id', function () {
+        return this.get('id').split('.').pop();
+    }),
+
+    // Helper methods
+    generateProfileId: function () {
         var id = makeId();
         var profileIds = this.get('profiles').map((profile) => profile.get('profileId').split('.')[0]);
         while (profileIds.indexOf(id) !== -1) {
@@ -38,10 +43,10 @@ export default DS.Model.extend(JamModel, {
         return `${this.get('id')}.${id}`;
     },
 
-    profileById: function(profileId) {
+    profileById: function (profileId) {
         // Scan the list of profiles and gets first one with matching ID (else undefined). Assumes profileIds are unique.
         var profiles = this.get('profiles') || [];
-        var getProfile = function(item) {
+        var getProfile = function (item) {
             return item.get('profileId') === profileId;
         };
 

--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -28,10 +28,8 @@ export default DS.Model.extend(JamModel, {
     history: DS.hasMany('history'),
     extra: DS.attr(),
 
-    // Username should be immutable, and calculated from the last portion of the record ID
-    username: Ember.computed('id', function () {
-        return this.get('id').split('.').pop();
-    }),
+    // Username should be immutable. We will use the id, which is already truncated from <namespace>.<collection>.(<recordId>) in jam-document-serializer
+    username: Ember.computed.alias('id'),
 
     // Helper methods
     generateProfileId: function () {


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-219

Companion to: https://github.com/CenterForOpenScience/lookit/pull/62

## Purpose
The username field is available on records as a convenience, but it is not canonical, and not every record in the database provides a value for it. (some specify null, others omit the field entirely)

We will replace this less-reliable field with a computed property, calculated from the record id: `namespace.collection.shortId` --> `shortId`.

(this calculation is already done in the serializer, but we'll keep the separate property for readability, and in case the serializer changes in the future)

## Summary of changes
 Deprecate the standalone username field in the model. Any existing `attributes.username` values will be ignored.

Replace this with a computed property that calculates username based on the last section of the record ID. This is more consistent with how JamDB logs users in, and reflects the fact that the username is an immutable field.


## Testing notes
This is expected to be a drop-in replacement for existing usages of the username value in Lookit and ISP.

Manually tested the following items:
- Login to existing account that has an attributes.username field in the record
- Login to existing account that does not have an attributes.username field
- Create a new account
- Reset password on an existing account (with and without username field)

- Verified that after logging in, expected username appears in the Lookit navbar and account info page.
- Verified that ISP app can log in correctly