### PR TITLE
Randomizer improvements

### DIFF
--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -52,7 +52,17 @@ export default DS.Model.extend(JamModel, {
     },
     pastSessionsFor(experiment, profile, isCompleted) {
         var profileId = Ember.get(profile, 'profileId');
-        var query = profileId ? { 'filter[profileId]': profileId } : {};
+
+        // For most applications, we will care about the newest past sessions first. Fetch as many of those results
+        // as possible so that any client side filtering has a chance of working as desired.
+        let query = {
+            'sort': '-created_on',
+            'page[size]': 100
+        };
+
+        if (profileId) {
+            query['filter[profileId]'] = profileId;
+        }
         if (typeof isCompleted !== 'undefined') {
             query['filter[completed]'] = isCompleted ? 1 : 0;
         }

--- a/exp-player/addon/randomizers/pref-phys-pilot.js
+++ b/exp-player/addon/randomizers/pref-phys-pilot.js
@@ -1,3 +1,5 @@
+import Ember from 'ember';
+
 // http://stackoverflow.com/a/12646864
 function shuffleArray(array) {
     for (var i = array.length - 1; i > 0; i--) {
@@ -72,7 +74,7 @@ function getConditions(lastSession, frameId) {
         showStay = lastFrameConditions.showStay;
         //parseInt(prompt("Show support-stay (1) or support-fall (0) last session?", "0/1"));
         showStay = 1 - showStay;
-        whichObjects = lastFrameConditions.whichObjects;
+        whichObjects = Ember.copy(lastFrameConditions.whichObjects);
         for (var i = 0; i < 4; i++) {
             whichObjects[i]++;
             if (whichObjects[i] > 5) {

--- a/exp-player/addon/randomizers/pref-phys-pilot.js
+++ b/exp-player/addon/randomizers/pref-phys-pilot.js
@@ -9,6 +9,17 @@ function shuffleArray(array) {
     return array;
 }
 
+/**
+ * Select the most recently completed session from an array of options, according to the specified rules
+ *
+ * @method getLastSession
+ * @param {Session[]} An array of session records
+ * @returns {Session} The model representing the last session in which the user participated
+ */
+function getLastSession (pastSessions) {
+    return pastSessions[0];
+}
+
 function getConditions(lastSession, frameId) {
     var startType, showStay, whichObjects;
     // The last session payload refers to the frame we want by number (#-frameName), but frames aren't numbered until the sequence
@@ -393,7 +404,8 @@ var randomizer = function (frameId, frameConfig, pastSessions, resolveFrame) {
     });
 
     // TODO: In the future, we may want to identify the specific frame # to fetch instead of generic frame name
-    var conditions = getConditions(pastSessions[0], frameId);
+    let lastSession = getLastSession(pastSessions);
+    var conditions = getConditions(lastSession, frameId);
 
     conditions.NPERTYPE = 6;
     var {
@@ -418,4 +430,4 @@ var randomizer = function (frameId, frameConfig, pastSessions, resolveFrame) {
 export default randomizer;
 
 // Export helper functions to support unit testing
-export { getConditions };
+export { getConditions, getLastSession };

--- a/exp-player/addon/randomizers/pref-phys-pilot.js
+++ b/exp-player/addon/randomizers/pref-phys-pilot.js
@@ -13,16 +13,19 @@ function shuffleArray(array) {
  * Select the first matching session from an array of options, according to the specified rules
  *
  * @method getLastSession
- * @param {Session[]} An array of session records. This returns the first match, eg assumes newest-first sort order
+ * @param {Session[]} pastSessions An array of session records. This returns the first match, eg assumes newest-first sort order
  * @returns {Session} The model representing the last session in which the user participated
  */
 function getLastSession (pastSessions) {
     // Base randomization on the newest (last completed) session for which the participant got at
     // least as far as recording data for a single video ID.
-    for (let session of pastSessions) {
+    for (let i=0; i < pastSessions.length; i++) {
+        let session = pastSessions[i];
         // Frames might be numbered differently in different experiments... rather than check for a frame ID, check that at least one frame referencing the videos exists at all.
         let expData = session.get('expData') || {};
-        for (let frameKeyName of Object.keys(expData)) {
+        let keys = Object.keys(expData);
+        for (let i=0; i < keys.length; i++) {
+            let frameKeyName = keys[i];
             let frameData = expData[frameKeyName];
             if (frameKeyName.indexOf('pref-phys-videos') !== -1 && frameData && frameData.videoId) {
                 return session;

--- a/exp-player/tests/unit/randomizers/pref-phys-pilot-test.js
+++ b/exp-player/tests/unit/randomizers/pref-phys-pilot-test.js
@@ -81,7 +81,7 @@ test('getLastSession returns null if existing session has no data for relevant f
         }
     });
     let actualResult = getLastSession([fakeSession]);
-    assert.equal(actualResult, null);
+    assert.equal(actualResult, null, `Expected null, got ${actualResult}`);
 });
 
 test('getLastSession returns null given a session that has expData, but not videoId', function(assert) {
@@ -91,7 +91,7 @@ test('getLastSession returns null given a session that has expData, but not vide
         }
     });
     let actualResult = getLastSession([fakeSession]);
-    assert.equal(actualResult, null);
+    assert.equal(actualResult, null, `Expected null, got ${actualResult}`);
 });
 
 test('getLastSession returns older or newer session as appropriate', function(assert) {

--- a/exp-player/tests/unit/randomizers/pref-phys-pilot-test.js
+++ b/exp-player/tests/unit/randomizers/pref-phys-pilot-test.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import { module } from 'qunit';
 import test from 'dummy/tests/ember-sinon-qunit/test';
 
-import { getConditions } from 'exp-player/randomizers/pref-phys-pilot';
+import { getConditions, getLastSession } from 'exp-player/randomizers/pref-phys-pilot';
 
 module('Unit | Randomizer | pref phys pilot');
 
@@ -72,4 +72,43 @@ test('If no prev conditions are specified, a random frame is returned', function
     assert.deepEqual(actualResult, expectedResult,
         'Randomizer should act randomly when no session is provided'
     );
+});
+
+test('getLastSession returns null if existing session has no data for relevant frame', function(assert) {
+    const fakeSession = Ember.Object.create({
+        expData: {
+            '1-jabberwocky': 'something'
+        }
+    });
+    let actualResult = getLastSession([fakeSession]);
+    assert.equal(actualResult, null);
+});
+
+test('getLastSession returns null given a session that has expData, but not videoId', function(assert) {
+    const fakeSession = Ember.Object.create({
+        expData: {
+            '1-pref-phys-videos': { videosShown: [] },
+        }
+    });
+    let actualResult = getLastSession([fakeSession]);
+    assert.equal(actualResult, null);
+});
+
+test('getLastSession returns older or newer session as appropriate', function(assert) {
+    const badFakeSession = Ember.Object.create({
+        expData: {
+            '1-pref-phys-videos': { videosShown: [] },
+        }
+    });
+    const goodFakeSession = Ember.Object.create({
+        expData: {
+            '2-pref-phys-videos': { videoId: 'abc' },
+        }
+    });
+
+    let actualResult = getLastSession([badFakeSession, goodFakeSession]);
+    assert.deepEqual(actualResult, goodFakeSession, 'Should return the older session');
+
+    actualResult = getLastSession([goodFakeSession, badFakeSession]);
+    assert.deepEqual(actualResult, goodFakeSession, 'Should return the newer session');
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-233
Companion to: 

## Purpose
Change the rules for how "previous session" is chosen in the counterbalancing randomizer for Lookit preferential physics study.

## Summary of changes
- [x] Fix the issue that limits session selection to the first 50. (this prevents it from getting newest)
- [x] Change rules for how session is selected
- [x] Add unit tests around desired behavior

## Testing notes
- [x] On a new account, verify random conditions are selected for first experiment
- [x] On a new account, verify random conditions are selected if no previous session meets criteria
- [x] On an existing account, perform a few sessions before leaving the consent screen. Verify that the correct "previous" session is used. (has at least one record of video ID)
- [x] Test this manually in safari (I experienced some weirdness in phantomjs... but flash player doesn't work anyway, so not a prime issue)