### PR TITLE
Add computed for disabling login button [LEI-238]

### DIFF
--- a/exp-models/addon/components/jam-auth/component.js
+++ b/exp-models/addon/components/jam-auth/component.js
@@ -13,7 +13,7 @@ export default Ember.Component.extend({
     authenticating: false,
     invalidAuth: false,
 
-    disabled: Ember.computed('username', 'password', 'authenticating', 'invalidAuth', function() {
+    disableLogin: Ember.computed('username', 'password', 'authenticating', 'invalidAuth', function() {
         return this.get('authenticating') || this.get('invalidAuth') || !(this.get('username') && this.get('password'));
     }),
 

--- a/exp-models/addon/components/jam-auth/component.js
+++ b/exp-models/addon/components/jam-auth/component.js
@@ -11,6 +11,11 @@ export default Ember.Component.extend({
     password: null,
 
     authenticating: false,
+    invalidAuth: false,
+
+    disabled: Ember.computed('username', 'password', 'authenticating', 'invalidAuth', function() {
+        return this.get('authenticating') || this.get('invalidAuth') || !(this.get('username') && this.get('password'));
+    }),
 
     actions: {
         authenticate() {

--- a/exp-models/addon/components/jam-auth/template.hbs
+++ b/exp-models/addon/components/jam-auth/template.hbs
@@ -13,7 +13,7 @@
         </div>
       </div>
       <div class="form-group">
-        <button class="btn btn-primary" onclick={{action 'authenticate'}}>Login</button>
+        <button disabled={{disableLogin}} class="btn btn-primary" onclick={{action 'authenticate'}}>Login</button>
       </div>
     </div>
 </div>


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-238
Companion to: https://github.com/CenterForOpenScience/isp/pull/77

## Purpose
Button is now also disabled if the invalidAuth modal is open.

## Summary of changes
- Add `disabled` computed to replace logic in the template
- Button is now also disabled if the `invalidAuth` modal is open (prevents flashing disabled --> enabled). When the user dismisses the modal, the button will be enabled and they will be able to re-submit the form with a correct username & password.