### PR TITLE
Feature/add rating question [LEI-241]

### DIFF
--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -301,7 +301,7 @@ var questions = [
         scale: TEN_POINT_SCALE,
         options: {
             labelTop: false,
-            formatLabel: 'measure-four',
+            formatLabel: 'measure-four negative-margin-top',
             labels: [
                 {
                     rating: 0,

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -464,14 +464,45 @@ var questions = [
         scale: ['measures.questions.11.options.yes', 'measures.questions.11.options.no'],
         items: [{
             type: 'radio',
-            value: null
+            value: null,
+            formatLabel: 'negative-margin-top'
         },
-            {
-                type: 'input',
-                description: 'measures.questions.12.label',
-                value: null,
-                optional: true
-            }]
+        {
+            type: 'textarea',
+            description: 'measures.questions.12.label',
+            value: null,
+            optional: true
+        },
+        {
+            type: 'radio',
+            description: 'measures.questions.18.label',
+            value: null,
+            optional: true,
+            labelTop: false,
+            scale: NINE_POINT_SCALE,
+            labels: [
+                {
+                    rating: 1,
+                    label: 'measures.questions.18.options.notatallSuccessful'
+                },
+                {
+                    rating: 3,
+                    label: 'measures.questions.18.options.alittleSuccessful'
+                },
+                {
+                    rating: 5,
+                    label: 'measures.questions.18.options.moderatelySuccessful'
+                },
+                {
+                    rating: 7,
+                    label: 'measures.questions.18.options.verySuccessful'
+                },
+                {
+                    rating: 9,
+                    label: 'measures.questions.18.options.completelySuccessful'
+                }
+            ]
+        }]
     },
     generateSchema({
         question: 'measures.questions.13.label',

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -16,13 +16,15 @@
         {{else if (eq question.type 'select')}}
           {{select-input options=question.scale value=question.items.0.value}}
         {{else if (eq question.type 'radio-input')}}
-          {{isp-radio-group options=question.scale value=question.items.0.value}}
-          <br>
+          {{isp-radio-group options=question.scale formatLabel=question.items.0.formatLabel value=question.items.0.value}}
           {{#if (eq question.items.0.value 'yes')}}
-            <label>{{t question.items.1.description}}</label>
-            {{#input value=question.items.1.value}}{{/input}}
+            <label class="label-margin-top">{{t question.items.1.description}}</label><br>
+            {{#textarea value=question.items.1.value rows="2" cols="35"}}{{/textarea}}<br>
+            <label class="label-margin-top">{{t question.items.2.description}}</label>
+            {{isp-radio-group options=question.items.2.scale labelTop=question.items.2.labelTop labels=question.items.2.labels value=question.items.2.value}}
             <br>
           {{/if}}
+          <br>
         {{/if}}
       {{/bs-form-group}}
     {{/if}}

--- a/exp-player/addon/styles/components/exp-rating-form.scss
+++ b/exp-player/addon/styles/components/exp-rating-form.scss
@@ -2,3 +2,7 @@
     margin-bottom: 25px;
     font-size: 16px;
 }
+
+.label-margin-top {
+    margin-top: 20px;
+}

--- a/exp-player/addon/styles/components/isp-radio-group.scss
+++ b/exp-player/addon/styles/components/isp-radio-group.scss
@@ -32,3 +32,7 @@
     width: 8%;
     margin-right: 20px;
 }
+
+.negative-margin-top {
+    margin-top: -25px;
+}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-241

## Purpose
Add in another optional question under question 10 on the rating-form, below "What aspect are you trying to change?"

## Summary of changes
- Add rating form question that only shows up when a user answers "yes" to question 10:  
![screen shot 2016-10-06 at 11 07 33 am](https://cloud.githubusercontent.com/assets/6414394/19158021/3527c30c-8bb5-11e6-9fa9-58dcd679c2fb.png)



- Adjust spacing on question four so that there is less space between the question and answer options:  
![screen shot 2016-10-06 at 11 07 19 am](https://cloud.githubusercontent.com/assets/6414394/19158008/2d448b5c-8bb5-11e6-9fd5-41da47f30ee5.png)



## Notes
- I noticed the question's wording seems incorrect so I asked for clarification (but that change would occur in `translations.js`