### PR TITLE
Send passwords to server as written and other tweaks

### DIFF
--- a/exp-models/addon/components/jam-auth/component.js
+++ b/exp-models/addon/components/jam-auth/component.js
@@ -22,8 +22,8 @@ export default Ember.Component.extend({
             this.set('authenticating', true);
             return this.get('login')({
                 provider: 'self',
-                username: this.get('username').trim(),
-                password: this.get('password').trim(),
+                username: this.get('username'),
+                password: this.get('password'),
                 namespace: this.get('namespaceConfig.namespace'),
                 collection: this.get('collection')
             }).finally(() => this.set('authenticating', true));

--- a/exp-models/addon/models/session.js
+++ b/exp-models/addon/models/session.js
@@ -1,5 +1,5 @@
 /*
-Manage data about one or more documents in the sessions collection
+ Manage data about one or more documents in the sessions collection
  */
 
 import Ember from 'ember';
@@ -31,15 +31,16 @@ export default DS.Model.extend(AnonJamModel, {
     history: DS.hasMany('history'),
 
     getProfile() {
-	let [accountId, ] = this.get('profileId').split('.');
-	return this.store.findRecord('account', accountId).then((account) => account.profileById(this.get('profileId')));
+        let [accountId, ] = this.get('profileId').split('.');
+        return this.store.findRecord('account', accountId).then((account) => account.profileById(this.get('profileId')));
     },
-    anonProfileId: Ember.computed('profileId', function() {
+    anonProfileId: Ember.computed('profileId', function () {
         // For a profile id of format `<acctShortId>.random`, strip off the identifying account ID
         var profileId = this.get('profileId');
-        return profileId.split ? profileId.split('.')[1] : profileId;}),
+        return profileId.split ? profileId.split('.')[1] : profileId;
+    }),
 
-    experiment: Ember.computed('experimentId', function() {
+    experiment: Ember.computed('experimentId', function () {
         var storeId = this.get('experimentId');
         return this.store.findRecord('experiment', storeId);
     })

--- a/exp-player/addon/randomizers/pref-phys-pilot.js
+++ b/exp-player/addon/randomizers/pref-phys-pilot.js
@@ -18,15 +18,15 @@ function shuffleArray(array) {
  * @param {Session[]} pastSessions An array of session records. This returns the first match, eg assumes newest-first sort order
  * @returns {Session} The model representing the last session in which the user participated
  */
-function getLastSession (pastSessions) {
+function getLastSession(pastSessions) {
     // Base randomization on the newest (last completed) session for which the participant got at
     // least as far as recording data for a single video ID.
-    for (let i=0; i < pastSessions.length; i++) {
+    for (let i = 0; i < pastSessions.length; i++) {
         let session = pastSessions[i];
         // Frames might be numbered differently in different experiments... rather than check for a frame ID, check that at least one frame referencing the videos exists at all.
         let expData = session.get('expData') || {};
         let keys = Object.keys(expData);
-        for (let i=0; i < keys.length; i++) {
+        for (let i = 0; i < keys.length; i++) {
             let frameKeyName = keys[i];
             let frameData = expData[frameKeyName];
             if (frameKeyName.indexOf('pref-phys-videos') !== -1 && frameData && frameData.videoId) {

--- a/exp-player/addon/services/video-recorder.js
+++ b/exp-player/addon/services/video-recorder.js
@@ -109,7 +109,7 @@ const VideoRecorder = Ember.Object.extend({
             );
         }
 
-        $container.append(`<div id="${divId}"></div`);
+        $container.append(`<div id="${divId}"></div>`);
         $element.append($container);
         if (hidden) {
             $container.append(


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-245

## Purpose
Minor cleanup found while working on login ticket.

## Summary of changes
- Login now sends the exact username and password as typed. It does not try to remove characters (eg leading/trailing spaces). This should be more consistent with how JamDB login works.
- Fix malformed markup in video widget
- Minor automated syntax reformatting
