### PR TITLE
Make progressBarPage watch 'framePage' [LEI-254]

### DIFF
--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -602,7 +602,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
     layout: layout,
     framePage: 0,
     lastPage: 6,
-    progressBarPage: Ember.computed('currentPage', function () {
+    progressBarPage: Ember.computed('framePage', function () {
         return this.framePage + 5;
     }),
     questions: Ember.computed(function () {


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-254

On the exp-rating-form component, make the progressBarPage computed watch 'framePage'
as there is no 'currentPage' attribute.