### PR TITLE
Confirmation dialog when user withdraws their data

### DIFF
--- a/exp-player/addon/components/exp-exit-survey-pilot.js
+++ b/exp-player/addon/components/exp-exit-survey-pilot.js
@@ -81,12 +81,22 @@ export default ExpFrameBaseComponent.extend(Validations, FullScreen, {
     },
     today: new Date(),
     section1: true,
+    showWithdrawalConfirmation: false,
     showValidation: false,
     actions: {
+        advanceToProgressBar() {
+            // Move from section 1 (survey) to section 2 (progress bar/ finish button)
+            this.set('section1', false);
+            this.send('save');
+        },
         continue () {
+            // Check whether exit survey is valid, and if so, advance to next screen
             if (this.get('validations.isValid')) {
-                this.set('section1', false);
-                this.send('save');
+                if (this.get('withdrawal')) {
+                    this.set('showWithdrawalConfirmation', true);
+                } else {
+                    this.send('advanceToProgressBar');
+                }
             } else {
                 this.set('showValidation', true);
             }

--- a/exp-player/addon/components/exp-exit-survey.js
+++ b/exp-player/addon/components/exp-exit-survey.js
@@ -81,12 +81,22 @@ export default ExpFrameBaseComponent.extend(Validations, FullScreen, {
     },
     today: new Date(),
     section1: true,
+    showWithdrawalConfirmation: false,
     showValidation: false,
     actions: {
+        advanceToProgressBar() {
+            // Move from section 1 (survey) to section 2 (progress bar/ finish button)
+            this.set('section1', false);
+            this.send('save');
+        },
         continue () {
+            // Check whether exit survey is valid, and if so, advance to next screen
             if (this.get('validations.isValid')) {
-                this.set('section1', false);
-                this.send('save');
+                if (this.get('withdrawal')) {
+                    this.set('showWithdrawalConfirmation', true);
+                } else {
+                    this.send('advanceToProgressBar');
+                }
             } else {
                 this.set('showValidation', true);
             }

--- a/exp-player/addon/styles/addon.scss
+++ b/exp-player/addon/styles/addon.scss
@@ -30,10 +30,6 @@
     white-space: pre-wrap
 }
 
-.btn {
-    margin-bottom: 15px;
-}
-
 .exp-controls {
     margin: 5px;
 }

--- a/exp-player/addon/templates/components/exp-exit-survey-pilot.hbs
+++ b/exp-player/addon/templates/components/exp-exit-survey-pilot.hbs
@@ -5,8 +5,7 @@
                 {{exitThankYou}}
                 <hr>
                 <label>
-                    <i class="fa fa-star"></i> Please confirm your child's
-                    birthdate:
+                    <i class="fa fa-star"></i> Please confirm your child's birthdate:
                 </label>
                 {{bs-datetimepicker
                   format="MM/DD/YYYY"
@@ -120,20 +119,35 @@
                 <hr>
                 {{bs-button class="pull-right" defaultText="Submit" type="success" action='continue'}}
             {{/bs-form}}
+
+            {{!-- Withdrawal confirmation modal --}}
+            {{#bs-modal open=showWithdrawalConfirmation body=false footer=false submitAction=(action "advanceToProgressBar")}}
+                {{#bs-modal-body}}
+                    You have chosen to withdraw your video data from the study. Any video beyond your consent recording
+                    will be deleted without viewing. Are you sure?
+                {{/bs-modal-body}}
+                {{#bs-modal-footer as |footer|}}
+                    {{#bs-button type="default" action=(action "close" target=footer)}}Cancel{{/bs-button}}
+                    {{#bs-button type="danger" buttonType="submit"}}Withdraw{{/bs-button}}
+                {{/bs-modal-footer}}
+            {{/bs-modal}}
         {{else}}
             <h4>{{title2}}</h4>
-            <!--<p>Hooray! You have completed <strong>{{currentSessionsCompleted}}</strong> session(s) in <strong>{{currentDaysSessionsCompleted}}</strong> days. </p>
-        <p>We are asking parents to try to complete <strong>{{idealSessionsCompleted}}</strong> sessions within <strong>{{idealDaysSessionsCompleted}}</strong> days. (You can do up to two sessions per day.) If you reach this goal we will be able to send you an individualized report about your child's responses!</p>
-        <div class="progress">
-            <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow={{progressValue}} aria-valuemin="0" aria-valuemax="100" style="width:{{progressValue}}%">
-                {{progressValue}}% Complete
+            {{!--
+            <p>Hooray! You have completed <strong>{{currentSessionsCompleted}}</strong> session(s) in <strong>{{currentDaysSessionsCompleted}}</strong> days. </p>
+            <p>We are asking parents to try to complete <strong>{{idealSessionsCompleted}}</strong> sessions within <strong>{{idealDaysSessionsCompleted}}</strong> days. (You can do up to two sessions per day.) If you reach this goal we will be able to send you an individualized report about your child's responses!</p>
+            <div class="progress">
+                <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow={{progressValue}} aria-valuemin="0" aria-valuemax="100" style="width:{{progressValue}}%">
+                    {{progressValue}}% Complete
+                </div>
             </div>
-        </div>-->
+            --}}
             <hr>
             {{exitMessage}}
             <div class="form-group">
-
-                <!--<label>{{input type="checkbox" checked=emailOptOut name="emailOptOut"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Receive email reminders about this study.</span> </label>-->
+                {{!--
+                <label>{{input type="checkbox" checked=emailOptOut name="emailOptOut"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Receive email reminders about this study.</span> </label>
+                --}}
                 {{bs-button class="pull-right" defaultText="Return to Lookit" type="success" action='finish'}}
             </div>
         {{/if}}

--- a/exp-player/addon/templates/components/exp-exit-survey-pilot.hbs
+++ b/exp-player/addon/templates/components/exp-exit-survey-pilot.hbs
@@ -1,94 +1,141 @@
 <div class="row exp-physics-exit-survey">
     <div class="col-md-8 col-md-offset-2">
-        {{#if section1}} {{#bs-form}}
-        {{exitThankYou}}
-        <hr>
-        <label><i class="fa fa-star"></i> Please confirm your child's birthdate:</label> {{bs-datetimepicker format="MM/DD/YYYY" pickDate=false noIcon=true allowInputToggle=true updateDate=(action (mut birthDate)) maxDate=today}}
-        <div class="extra-info">We ask again just to check for typos during registration or accidental selection of a different child at the start of the study.</div>
-        {{#if showValidation}}
-        <p class="text text-danger">
-            {{ validations.attrs.birthDate.messages }}
-        </p>
-        {{/if}}
-        <hr>
-        <label><i class="fa fa-star"></i> Would you like to share your video and other data from this session with authorized users of the secure data library Databrary? </label>
-        <div class="radio">
-            <label>
-              <span class="radio-holder">{{radio-button value="no" checked=databraryShare name="databraryShare"}}</span>
-              No
-            </label>
-        </div>
-        <div class="radio">
-            <label>
-             <span class="radio-holder">{{radio-button value="yes" checked=databraryShare name="databraryShare"}}</span>
-             Yes
-           </label>
-        </div>
-        <div class="extra-info">Only authorized researchers will have access to information in the library. Researchers who are granted access must agree to maintain confidentiality and not use information for commercial purposes. Data sharing will lead to faster progress in research on human development and behavior. If you have any questions about the data-sharing library, please visit <a href="https://nyu.databrary.org/" target="_blank">Databrary </a> or email ethics@databrary.org. </div>
-        {{#if showValidation}}
-        <p class="text text-danger">
-            {{ validations.attrs.databraryShare.messages }}
-        </p>
-        {{/if}}
-        <hr>
-	<fieldset disabled={{withdrawal}} class="{{if withdrawal 'text-muted'}}">
-        <label><i class="fa fa-star"></i> Use of video clips and images:</label>
-        <div class="radio">
-            <label>
-            <span class="radio-holder">{{radio-button value="private" checked=useOfMedia name="useOfMedia"}}</span>
-            <strong>Private:</strong> Video may only be viewed by authorized scientists
-	    {{#if (eq databraryShare 'yes')}}
-		(researchers working on the Lookit project and authorized Databrary users).
-	    {{else}}
-		(researchers working on the Lookit project).
-	    {{/if}}
-          </label>
-        </div>
-        <div class="radio">
-            <label>
-               <span class="radio-holder">{{radio-button value="scientific" checked=useOfMedia name="useOfMedia"}}</span>
-               <strong>Scientific and educational:</strong> Video may be shared for scientific or educational purposes. For example, we might show a video clip in a talk at a scientific conference or an undergraduate class about cognitive development, or include an image or video in a scientific paper. In some circumstances, video or images may be available online, for instance as supplemental material in a scientific paper.
-             </label>
-        </div>
-        <div class="radio">
-            <label>
-              <span class="radio-holder">{{radio-button value="public" checked=useOfMedia name="useOfMedia"}}</span>
-              <strong>Publicity:</strong> Please select this option if you'd be excited about seeing your child featured on the Lookit website or in a news article about this study! Your video may be shared for publicity as well as scientific and educational purposes; it will never be used for commercial purposes. Video clips shared may be available online to the general public.
-            </label>
-        </div>
-        {{#if showValidation}}
-        <p class="text text-danger">
-            {{ validations.attrs.useOfMedia.messages }}
-        </p>
-        {{/if}}
-	</fieldset>
-        <hr>
-        <label>Withdrawal of video data </label>
-        <label>{{input type="checkbox" checked=withdrawal name="withdrawal"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Every video helps us, even if something went wrong! However, if you need your video deleted (your spouse was discussing state secrets in the background, etc.), check here to completely withdraw your video data from this session from the study. Only your consent video will be retained and it may only be viewed by Lookit researchers; other video will be deleted without viewing.</span> </label>
-        <hr>
-        <div class="form-group">
-            <label>Your feedback:</label><br> {{textarea class="input-text" value=feedback name="feedback" rows=3 cols=40}}
-        </div>
-        <hr>
-        {{bs-button class="pull-right" defaultText="Submit" type="success" action='continue'}} {{/bs-form}}
-
+        {{#if section1}}
+            {{#bs-form}}
+                {{exitThankYou}}
+                <hr>
+                <label>
+                    <i class="fa fa-star"></i> Please confirm your child's
+                    birthdate:
+                </label>
+                {{bs-datetimepicker
+                  format="MM/DD/YYYY"
+                  pickDate=false
+                  noIcon=true
+                  allowInputToggle=true
+                  updateDate=(action (mut birthDate))
+                  maxDate=today}}
+                <div class="extra-info">We ask again just to check for typos during registration or accidental selection
+                    of a different child at the start of the study.
+                </div>
+                {{#if showValidation}}
+                    <p class="text text-danger">
+                        {{validations.attrs.birthDate.messages}}
+                    </p>
+                {{/if}}
+                <hr>
+                <label><i class="fa fa-star"></i> Would you like to share your video and other data from this session
+                    with authorized users of the secure data library Databrary? </label>
+                <div class="radio">
+                    <label>
+                        <span class="radio-holder">
+                            {{radio-button value="no" checked=databraryShare name="databraryShare"}}
+                        </span>
+                        No
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                        <span class="radio-holder">
+                            {{radio-button value="yes" checked=databraryShare name="databraryShare"}}
+                        </span>
+                        Yes
+                    </label>
+                </div>
+                <div class="extra-info">Only authorized researchers will have access to information in the library.
+                    Researchers who are granted access must agree to maintain confidentiality and not use information
+                    for commercial purposes. Data sharing will lead to faster progress in research on human development
+                    and behavior. If you have any questions about the data-sharing library, please visit <a
+                            href="https://nyu.databrary.org/" target="_blank">Databrary </a> or email
+                    ethics@databrary.org.
+                </div>
+                {{#if showValidation}}
+                    <p class="text text-danger">
+                        {{validations.attrs.databraryShare.messages}}
+                    </p>
+                {{/if}}
+                <hr>
+                <fieldset disabled={{withdrawal}} class="{{if withdrawal 'text-muted'}}">
+                    <label><i class="fa fa-star"></i> Use of video clips and images:</label>
+                    <div class="radio">
+                        <label>
+                            <span class="radio-holder">
+                                {{radio-button value="private" checked=useOfMedia name="useOfMedia"}}
+                            </span>
+                            <strong>Private:</strong> Video may only be viewed by authorized scientists
+                            {{#if (eq databraryShare 'yes')}}
+                                (researchers working on the Lookit project and authorized Databrary users).
+                            {{else}}
+                                (researchers working on the Lookit project).
+                            {{/if}}
+                        </label>
+                    </div>
+                    <div class="radio">
+                        <label>
+                            <span class="radio-holder">
+                                {{radio-button value="scientific" checked=useOfMedia name="useOfMedia"}}
+                            </span>
+                            <strong>Scientific and educational:</strong> Video may be shared for scientific or
+                            educational purposes. For example, we might show a video clip in a talk at a scientific
+                            conference or an undergraduate class about cognitive development, or include an image or
+                            video in a scientific paper. In some circumstances, video or images may be available online,
+                            for instance as supplemental material in a scientific paper.
+                        </label>
+                    </div>
+                    <div class="radio">
+                        <label>
+                            <span class="radio-holder">
+                                {{radio-button value="public" checked=useOfMedia name="useOfMedia"}}
+                            </span>
+                            <strong>Publicity:</strong> Please select this option if you'd be excited about seeing your
+                            child featured on the Lookit website or in a news article about this study! Your video may
+                            be shared for publicity as well as scientific and educational purposes; it will never be
+                            used for commercial purposes. Video clips shared may be available online to the general
+                            public.
+                        </label>
+                    </div>
+                    {{#if showValidation}}
+                        <p class="text text-danger">
+                            {{validations.attrs.useOfMedia.messages}}
+                        </p>
+                    {{/if}}
+                </fieldset>
+                <hr>
+                <label>Withdrawal of video data </label>
+                <label>
+                    {{input type="checkbox" checked=withdrawal name="withdrawal"}}
+                    <span class="extra-info">
+                        &nbsp;&nbsp;&nbsp; Every video helps us, even if something went wrong! However, if you need
+                        your video deleted (your spouse was discussing state secrets in the background, etc.), check
+                        here to completely withdraw your video data from this session from the study. Only your consent
+                        video will be retained and it may only be viewed by Lookit researchers; other video will be
+                        deleted without viewing.
+                    </span>
+                </label>
+                <hr>
+                <div class="form-group">
+                    <label>Your
+                        feedback:</label><br> {{textarea class="input-text" value=feedback name="feedback" rows=3 cols=40}}
+                </div>
+                <hr>
+                {{bs-button class="pull-right" defaultText="Submit" type="success" action='continue'}}
+            {{/bs-form}}
         {{else}}
-
-        <h4>{{title2}}</h4>
-        <!--<p>Hooray! You have completed <strong>{{currentSessionsCompleted}}</strong> session(s) in <strong>{{currentDaysSessionsCompleted}}</strong> days. </p>
+            <h4>{{title2}}</h4>
+            <!--<p>Hooray! You have completed <strong>{{currentSessionsCompleted}}</strong> session(s) in <strong>{{currentDaysSessionsCompleted}}</strong> days. </p>
         <p>We are asking parents to try to complete <strong>{{idealSessionsCompleted}}</strong> sessions within <strong>{{idealDaysSessionsCompleted}}</strong> days. (You can do up to two sessions per day.) If you reach this goal we will be able to send you an individualized report about your child's responses!</p>
         <div class="progress">
             <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow={{progressValue}} aria-valuemin="0" aria-valuemax="100" style="width:{{progressValue}}%">
                 {{progressValue}}% Complete
             </div>
         </div>-->
-        <hr>
-        {{exitMessage}}
-        <div class="form-group">
+            <hr>
+            {{exitMessage}}
+            <div class="form-group">
 
-            <!--<label>{{input type="checkbox" checked=emailOptOut name="emailOptOut"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Receive email reminders about this study.</span> </label>-->
-            {{bs-button class="pull-right" defaultText="Return to Lookit" type="success" action='finish'}}
-        </div>
+                <!--<label>{{input type="checkbox" checked=emailOptOut name="emailOptOut"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Receive email reminders about this study.</span> </label>-->
+                {{bs-button class="pull-right" defaultText="Return to Lookit" type="success" action='finish'}}
+            </div>
         {{/if}}
     </div>
 </div>

--- a/exp-player/addon/templates/components/exp-exit-survey.hbs
+++ b/exp-player/addon/templates/components/exp-exit-survey.hbs
@@ -121,9 +121,10 @@
             <hr>
             {{!--
             <div class="form-group">
-            <label>{{input type="checkbox" checked=emailOptOut name="emailOptOut"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Receive email reminders about this study.</span> </label> {{bs-button class="pull-right" defaultText="Continue" type="success" action='finish'}}
+            <label>{{input type="checkbox" checked=emailOptOut name="emailOptOut"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Receive email reminders about this study.</span> </label>
             </div>
             --}}
+            {{bs-button class="pull-right" defaultText="Finish" type="success" action='finish'}}
         {{/if}}
     </div>
 </div>

--- a/exp-player/addon/templates/components/exp-exit-survey.hbs
+++ b/exp-player/addon/templates/components/exp-exit-survey.hbs
@@ -121,7 +121,8 @@
             {{!-- Withdrawal confirmation modal --}}
             {{#bs-modal open=showWithdrawalConfirmation body=false footer=false submitAction=(action "advanceToProgressBar")}}
                 {{#bs-modal-body}}
-                    You have chosen to withdraw your data from the study. Your videos will be deleted without viewing. Are you sure?
+                    You have chosen to withdraw your video data from the study. Any video beyond your consent recording
+                    will be deleted without viewing. Are you sure?
                 {{/bs-modal-body}}
                 {{#bs-modal-footer as |footer|}}
                     {{#bs-button type="default" action=(action "close" target=footer)}}Cancel{{/bs-button}}

--- a/exp-player/addon/templates/components/exp-exit-survey.hbs
+++ b/exp-player/addon/templates/components/exp-exit-survey.hbs
@@ -1,86 +1,129 @@
 <div class="row exp-physics-exit-survey">
     <div class="col-md-8 col-md-offset-2">
-        {{#if section1}} {{#bs-form}}
-        <label><i class="fa fa-star"></i> Please confirm your child's birthdate:</label> {{bs-datetimepicker format="MM/DD/YYYY" pickDate=false noIcon=true allowInputToggle=true updateDate=(action (mut birthDate)) maxDate=today}}
-        <div class="extra-info">We ask again just to check for typos during registration or accidental selection of a different child at the start of the study.</div>
-        {{#if showValidation}}
-        <p class="text text-danger">
-            {{ validations.attrs.birthDate.messages }}
-        </p>
-        {{/if}}
-        <hr>
-        <label><i class="fa fa-star"></i> Would you like to share your video and other data from this session with authorized users of the secure data library Databrary? </label>
-        <div class="radio">
-            <label>
-              <span class="radio-holder">{{radio-button value="no" checked=databraryShare name="databraryShare"}}</span>
-              No
-            </label>
-        </div>
-        <div class="radio">
-            <label>
-             <span class="radio-holder">{{radio-button value="yes" checked=databraryShare name="databraryShare"}}</span>
-             Yes
-           </label>
-        </div>
-        <div class="extra-info">Only authorized researchers will have access to information in the library. Researchers who are granted access must agree to maintain confidentiality and not use information for commercial purposes. Data sharing will lead to faster progress in research on human development and behavior. If you have any questions about the data-sharing library, please visit <a href="https://nyu.databrary.org/" target="_blank">Databrary </a> or email ethics@databrary.org. </div>
-        {{#if showValidation}}
-        <p class="text text-danger">
-            {{ validations.attrs.databraryShare.messages }}
-        </p>
-        {{/if}}
-        <hr>
-	<fieldset disabled={{withdrawal}} class="{{if withdrawal 'text-muted'}}">
-        <label><i class="fa fa-star"></i> Use of video clips and images:</label>
-        <div class="radio">
-            <label>
-            <span class="radio-holder">{{radio-button value="private" checked=useOfMedia name="useOfMedia"}}</span>
-            <strong>Private:</strong> Video may only be viewed by authorized scientists
-	    {{#if (eq databraryShare 'yes')}}
-		(researchers working on the Lookit project and authorized Databrary users).
-	    {{else}}
-		(researchers working on the Lookit project).
-	    {{/if}}
-          </label>
-        </div>
-        <div class="radio">
-            <label>
-               <span class="radio-holder">{{radio-button value="scientific" checked=useOfMedia name="useOfMedia"}}</span>
-               <strong>Scientific and educational:</strong> Video may be shared for scientific or educational purposes. For example, we might show a video clip in a talk at a scientific conference or an undergraduate class about cognitive development, or include an image or video in a scientific paper. In some circumstances, video or images may be available online, for instance as supplemental material in a scientific paper.
-             </label>
-        </div>
-        <div class="radio">
-            <label>
-              <span class="radio-holder">{{radio-button value="public" checked=useOfMedia name="useOfMedia"}}</span>
-              <strong>Publicity:</strong> Please select this option if you'd be excited about seeing your child featured on the Lookit website or in a news article about this study! Your video may be shared for publicity as well as scientific and educational purposes; it will never be used for commercial purposes. Video clips shared may be available online to the general public.
-            </label>
-        </div>
-        {{#if showValidation}}
-        <p class="text text-danger">
-            {{ validations.attrs.useOfMedia.messages }}
-        </p>
-        {{/if}}
-	</fieldset>
-        <hr>
-        <label>Withdrawal of video data </label>
-        <label>{{input type="checkbox" checked=withdrawal name="withdrawal"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Every video helps us, even if something went wrong! However, if you need your video deleted (your spouse was discussing state secrets in the background, etc.), check here to completely withdraw your video data from this session from the study. Only your consent video will be retained and it may only be viewed by Lookit researchers; other video will be deleted without viewing.</span> </label>
-        <hr>
-        <div class="form-group">
-            <label>Your feedback:</label><br> {{textarea class="input-text" value=feedback name="feedback" rows=3 cols=40}}
-        </div>
-        <hr>
-        {{bs-button class="pull-right" defaultText="Return to Lookit" type="success" action='continue'}} {{/bs-form}} {{else}}
-        <h4>{{title2}}</h4>
-        <p>Hooray! You have completed <strong>{{currentSessionsCompleted}}</strong> session(s) in <strong>{{currentDaysSessionsCompleted}}</strong> days. </p>
-        <p>We are asking parents to try to complete <strong>{{idealSessionsCompleted}}</strong> sessions within <strong>{{idealDaysSessionsCompleted}}</strong> days. (You can do up to two sessions per day.) If you reach this goal we will be able to send you an individualized report about your child's responses!</p>
-        <div class="progress">
-            <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow={{progressValue}} aria-valuemin="0" aria-valuemax="100" style="width:{{progressValue}}%">
-                {{progressValue}}% Complete
+        {{#if section1}}
+            {{#bs-form}}
+                <label>
+                    <i class="fa fa-star"></i> Please confirm your child's birthdate:
+                </label>
+                {{bs-datetimepicker format="MM/DD/YYYY" pickDate=false noIcon=true allowInputToggle=true updateDate=(action (mut birthDate)) maxDate=today}}
+                <div class="extra-info">We ask again just to check for typos during registration or accidental selection
+                    of a different child at the start of the study.
+                </div>
+                {{#if showValidation}}
+                    <p class="text text-danger">
+                        {{validations.attrs.birthDate.messages}}
+                    </p>
+                {{/if}}
+                <hr>
+                <label><i class="fa fa-star"></i> Would you like to share your video and other data from this session
+                    with authorized users of the secure data library Databrary? </label>
+                <div class="radio">
+                    <label>
+                        <span class="radio-holder">
+                            {{radio-button value="no" checked=databraryShare name="databraryShare"}}
+                        </span>
+                        No
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                        <span class="radio-holder">
+                            {{radio-button value="yes" checked=databraryShare name="databraryShare"}}
+                        </span>
+                        Yes
+                    </label>
+                </div>
+                <div class="extra-info">Only authorized researchers will have access to information in the library.
+                    Researchers who are granted access must agree to maintain confidentiality and not use information
+                    for commercial purposes. Data sharing will lead to faster progress in research on human development
+                    and behavior. If you have any questions about the data-sharing library, please visit <a
+                            href="https://nyu.databrary.org/" target="_blank">Databrary </a> or email
+                    ethics@databrary.org.
+                </div>
+                {{#if showValidation}}
+                    <p class="text text-danger">
+                        {{validations.attrs.databraryShare.messages}}
+                    </p>
+                {{/if}}
+                <hr>
+                <fieldset disabled={{withdrawal}} class="{{if withdrawal 'text-muted'}}">
+                    <label><i class="fa fa-star"></i> Use of video clips and images:</label>
+                    <div class="radio">
+                        <label>
+                            <span class="radio-holder">
+                                {{radio-button value="private" checked=useOfMedia name="useOfMedia"}}
+                            </span>
+                            <strong>Private:</strong> Video may only be viewed by authorized scientists
+                            {{#if (eq databraryShare 'yes')}}
+                                (researchers working on the Lookit project and authorized Databrary users).
+                            {{else}}
+                                (researchers working on the Lookit project).
+                            {{/if}}
+                        </label>
+                    </div>
+                    <div class="radio">
+                        <label>
+                            <span class="radio-holder">
+                                {{radio-button value="scientific" checked=useOfMedia name="useOfMedia"}}
+                            </span>
+                            <strong>Scientific and educational:</strong> Video may be shared for scientific or
+                            educational purposes. For example, we might show a video clip in a talk at a scientific
+                            conference or an undergraduate class about cognitive development, or include an image or
+                            video in a scientific paper. In some circumstances, video or images may be available online,
+                            for instance as supplemental material in a scientific paper.
+                        </label>
+                    </div>
+                    <div class="radio">
+                        <label>
+                            <span class="radio-holder">
+                                {{radio-button value="public" checked=useOfMedia name="useOfMedia"}}
+                            </span>
+                            <strong>Publicity:</strong> Please select this option if you'd be excited about seeing your
+                            child featured on the Lookit website or in a news article about this study! Your video may
+                            be shared for publicity as well as scientific and educational purposes; it will never be
+                            used for commercial purposes. Video clips shared may be available online to the general
+                            public.
+                        </label>
+                    </div>
+                    {{#if showValidation}}
+                        <p class="text text-danger">
+                            {{validations.attrs.useOfMedia.messages}}
+                        </p>
+                    {{/if}}
+                </fieldset>
+                <hr>
+                <label>Withdrawal of video data </label>
+                <label>
+                    {{input type="checkbox" checked=withdrawal name="withdrawal"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Every video helps us, even if something went wrong! However, if you need your video deleted (your spouse was discussing state secrets in the background, etc.), check here to completely withdraw your video data from this session from the study. Only your consent video will be retained and it may only be viewed by Lookit researchers; other video will be deleted without viewing.</span>
+                </label>
+                <hr>
+                <div class="form-group">
+                    <label>Your
+                        feedback:</label><br> {{textarea class="input-text" value=feedback name="feedback" rows=3 cols=40}}
+                </div>
+                <hr>
+                {{bs-button class="pull-right" defaultText="Return to Lookit" type="success" action='continue'}}
+            {{/bs-form}}
+        {{else}}
+            <h4>{{title2}}</h4>
+            <p>Hooray! You have completed <strong>{{currentSessionsCompleted}}</strong> session(s) in
+                <strong>{{currentDaysSessionsCompleted}}</strong> days. </p>
+            <p>We are asking parents to try to complete <strong>{{idealSessionsCompleted}}</strong> sessions within
+                <strong>{{idealDaysSessionsCompleted}}</strong> days. (You can do up to two sessions per day.) If you
+                reach this goal we will be able to send you an individualized report about your child's responses!</p>
+            <div class="progress">
+                <div class="progress-bar progress-bar-success" role="progressbar"
+                     aria-valuenow={{progressValue}} aria-valuemin="0" aria-valuemax="100"
+                     style="width:{{progressValue}}%">
+                    {{progressValue}}% Complete
+                </div>
             </div>
-        </div>
-        <hr>
-        <!--<div class="form-group">
+            <hr>
+            {{!--
+            <div class="form-group">
             <label>{{input type="checkbox" checked=emailOptOut name="emailOptOut"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Receive email reminders about this study.</span> </label> {{bs-button class="pull-right" defaultText="Continue" type="success" action='finish'}}
-        </div>-->
+            </div>
+            --}}
         {{/if}}
     </div>
 </div>

--- a/exp-player/addon/templates/components/exp-exit-survey.hbs
+++ b/exp-player/addon/templates/components/exp-exit-survey.hbs
@@ -115,7 +115,7 @@
                         feedback:</label><br> {{textarea class="input-text" value=feedback name="feedback" rows=3 cols=40}}
                 </div>
                 <hr>
-                {{bs-button class="pull-right" defaultText="Return to Lookit" type="success" action='continue'}}
+                {{bs-button class="pull-right" defaultText="Submit" type="success" action='continue'}}
             {{/bs-form}}
 
             {{!-- Withdrawal confirmation modal --}}

--- a/exp-player/addon/templates/components/exp-exit-survey.hbs
+++ b/exp-player/addon/templates/components/exp-exit-survey.hbs
@@ -5,7 +5,13 @@
                 <label>
                     <i class="fa fa-star"></i> Please confirm your child's birthdate:
                 </label>
-                {{bs-datetimepicker format="MM/DD/YYYY" pickDate=false noIcon=true allowInputToggle=true updateDate=(action (mut birthDate)) maxDate=today}}
+                {{bs-datetimepicker
+                  format="MM/DD/YYYY"
+                  pickDate=false
+                  noIcon=true
+                  allowInputToggle=true
+                  updateDate=(action (mut birthDate))
+                  maxDate=today}}
                 <div class="extra-info">We ask again just to check for typos during registration or accidental selection
                     of a different child at the start of the study.
                 </div>
@@ -94,7 +100,14 @@
                 <hr>
                 <label>Withdrawal of video data </label>
                 <label>
-                    {{input type="checkbox" checked=withdrawal name="withdrawal"}}<span class="extra-info">&nbsp;&nbsp;&nbsp; Every video helps us, even if something went wrong! However, if you need your video deleted (your spouse was discussing state secrets in the background, etc.), check here to completely withdraw your video data from this session from the study. Only your consent video will be retained and it may only be viewed by Lookit researchers; other video will be deleted without viewing.</span>
+                    {{input type="checkbox" checked=withdrawal name="withdrawal"}}
+                    <span class="extra-info">
+                        &nbsp;&nbsp;&nbsp; Every video helps us, even if something went wrong! However, if you need
+                        your video deleted (your spouse was discussing state secrets in the background, etc.), check
+                        here to completely withdraw your video data from this session from the study. Only your consent
+                        video will be retained and it may only be viewed by Lookit researchers; other video will be
+                        deleted without viewing.
+                    </span>
                 </label>
                 <hr>
                 <div class="form-group">
@@ -104,6 +117,17 @@
                 <hr>
                 {{bs-button class="pull-right" defaultText="Return to Lookit" type="success" action='continue'}}
             {{/bs-form}}
+
+            {{!-- Withdrawal confirmation modal --}}
+            {{#bs-modal open=showWithdrawalConfirmation body=false footer=false submitAction=(action "advanceToProgressBar")}}
+                {{#bs-modal-body}}
+                    You have chosen to withdraw your data from the study. Your videos will be deleted without viewing. Are you sure?
+                {{/bs-modal-body}}
+                {{#bs-modal-footer as |footer|}}
+                    {{#bs-button action=(action "close" target=footer)}}Cancel{{/bs-button}}
+                    {{#bs-button buttonType="submit" type="danger"}}Withdraw{{/bs-button}}
+                {{/bs-modal-footer}}
+            {{/bs-modal}}
         {{else}}
             <h4>{{title2}}</h4>
             <p>Hooray! You have completed <strong>{{currentSessionsCompleted}}</strong> session(s) in

--- a/exp-player/addon/templates/components/exp-exit-survey.hbs
+++ b/exp-player/addon/templates/components/exp-exit-survey.hbs
@@ -124,8 +124,8 @@
                     You have chosen to withdraw your data from the study. Your videos will be deleted without viewing. Are you sure?
                 {{/bs-modal-body}}
                 {{#bs-modal-footer as |footer|}}
-                    {{#bs-button action=(action "close" target=footer)}}Cancel{{/bs-button}}
-                    {{#bs-button buttonType="submit" type="danger"}}Withdraw{{/bs-button}}
+                    {{#bs-button type="default" action=(action "close" target=footer)}}Cancel{{/bs-button}}
+                    {{#bs-button type="danger" buttonType="submit"}}Withdraw{{/bs-button}}
                 {{/bs-modal-footer}}
             {{/bs-modal}}
         {{else}}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-249
Companion to: TBD (will need to update Lookit submodule commit)

## Purpose
Improve the experiment exit survey.

## Summary of changes
- [x] Add confirmation dialog if user wants to withdraw their results from an experiment
- [x] Make sure that sessions are correctly marked as completed at conclusion of the study
- ~~Fix "Number sessions completed" indicator to filter by completed flag (moved to separate ticket)~~

<img width="1157" alt="screen shot 2016-10-12 at 10 54 21 pm" src="https://cloud.githubusercontent.com/assets/2957073/19335181/3f6fac66-90cf-11e6-9a13-83c06ac586c4.png">


## Testing notes
This affects the last frame (exit survey) when completing a study.

To test locally, you can change code to make the study run faster. See JIRA ticket for notes on what variables to modify.

## Intended behaviors
- [x] When user selects "withdrawal", they are given a confirmation box.
  - [x] If they click "Cancel", they return to section 1 of the exit survey and can change their mind
  - [x] If they click "withdraw", they move to section 2
  - [x] If they click cancel, then continue without changing the checkbox setting, they will see the modal again (modal appears every time they try to advance with checkbox active)
- [x] When "withdrawal" box is not checked, the user sees no modal.