### PR TITLE
[rfr] Flags and timing events for various kinds of early exit

### DIFF
--- a/exp-models/addon/models/session.js
+++ b/exp-models/addon/models/session.js
@@ -13,6 +13,10 @@ export default DS.Model.extend(AnonJamModel, {
     conditions: DS.attr(),
     expData: DS.attr(),  // Data is a reserved keyword in ember
 
+    // Timing information for events captured by the player but not tied to a specific frame. Eg, early exit
+    //  from experiment
+    globalEventTimings: DS.attr({ defaultValue: () => [] }),
+
     profileId: DS.attr('string'), // Store ID of related record
 
     experimentId: DS.attr('string'),

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -35,10 +35,11 @@ export default Ember.Component.extend(FullScreen, {
                 // There is no guarantee that the server request to save this event will finish before exit completed;
                 //   we are limited in our ability to prevent willful exits
                 this.send('setGlobalTimeEvent', 'exitEarly', {
-                    exitType: 'browserNavigation',
+                    exitType: 'browserNavigationAttempt', // Page navigation, closed browser, etc
                     lastPageSeen: this.get('frameIndex') + 1
                 });
-                this.get('session').save();
+                //Ensure sync - try to force save to finish before exit
+                Ember.run(() => this.get('session').save());
 
                 // Then attempt to warn the user and exit
                 let toast = this.get('toast');

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -26,18 +26,19 @@ export default Ember.Component.extend(FullScreen, {
     allowExit: false,
     hasAttemptedExit: false,
     _registerHandlers() {
-        $(window).on('beforeunload', () => {
+        $(window).on('beforeunload', (e) => {
             if (!this.get('allowExit')) {
                 this.set('hasAttemptedExit', true);
                 this.send('exitFullscreen');
                 let toast = this.get('toast');
                 toast.warning('To leave the study early, press F1 and then select a privacy level for your videos');
-                return `
+                // Newer browsers will ignore the custom message below. See https://bugs.chromium.org/p/chromium/issues/detail?id=587940
+                const message = `
 If you're sure you'd like to leave this study early
 you can do so now.
 
 We'd appreciate it if before you leave you fill out a
-very breif exit survey letting us know how we can use
+very brief exit survey letting us know how we can use
 any video captured during this session. Press 'Stay on
 this Page' and you will be prompted to go to this
 exit survey.
@@ -45,6 +46,8 @@ exit survey.
 If leaving this page was an accident you will be
 able to continue the study.
 `;
+                e.returnValue = message;
+                return message;
             }
             return null;
         });

--- a/exp-player/index.js
+++ b/exp-player/index.js
@@ -7,335 +7,336 @@ var BroccoliMergeTrees = require('broccoli-merge-trees');
 
 
 module.exports = {
-  name: 'exp-player',
+    name: 'exp-player',
 
-  isDevelopingAddon: function() {
-      return true;
-  },
 
-  included: function(app) {
-    this._super.included(app);
-    this.app.import(path.join(this.app.bowerDirectory, 'swfobject/swfobject/src/swfobject.js'));
-  },
+    isDevelopingAddon: function () {
+        return true;
+    },
 
-  treeForPublic: function(app) {
-    var clientConfig = this.app.options.emberWowza || {};
-    clientConfig.php = clientConfig.php || {};
-    clientConfig.asp = clientConfig.asp || {};
+    included: function (app) {
+        this._super.included(app);
+        this.app.import(path.join(this.app.bowerDirectory, 'swfobject/swfobject/src/swfobject.js'));
+    },
 
-    var config = {};
-    config.php = Object.keys(DEFAULT_OPTIONS).reduce(function(acc, key) {
-      acc[key] = clientConfig.php[key] || DEFAULT_OPTIONS[key];
-      return acc;
-    }, {});
-    config.asp = Object.keys(DEFAULT_OPTIONS).reduce(function(acc, key) {
-      acc[key] = clientConfig.asp[key] || DEFAULT_OPTIONS[key];
-      return acc;
-    }, {});
+    treeForPublic: function (app) {
+        var clientConfig = this.app.options.emberWowza || {};
+        clientConfig.php = clientConfig.php || {};
+        clientConfig.asp = clientConfig.asp || {};
 
-    return new BroccoliMergeTrees([
-      generate(null, {
-        file: 'avc_settings.php',
-        template: '{{php}}',
-          values: {
-            php: Object.keys(config.php).map(function(key) {
-              return key + '=' + config.php[key];
-            }).join('&')
-          }
-      }),
-      generate(null, {
-        file: 'avc_settings.asp',
-        template: '{{asp}}',
-          values: {
-            asp: Object.keys(config.asp).map(function(key) {
-              return key + '=' + config.asp[key];
-            }).join('&')
-          }
-      }),
-      new Funnel(path.join(path.resolve(this.root, ''),  'public/'), {
-        srcDir: '/',
-        destDir: '/',
-        include: ['**/*.swf', '**/*.gif', '**/*.png', '**/*.jpg', '**/*.xml', '**/*.php']
-      })
-    ]);
-  }
+        var config = {};
+        config.php = Object.keys(DEFAULT_OPTIONS).reduce(function (acc, key) {
+            acc[key] = clientConfig.php[key] || DEFAULT_OPTIONS[key];
+            return acc;
+        }, {});
+        config.asp = Object.keys(DEFAULT_OPTIONS).reduce(function (acc, key) {
+            acc[key] = clientConfig.asp[key] || DEFAULT_OPTIONS[key];
+            return acc;
+        }, {});
+
+        return new BroccoliMergeTrees([
+            generate(null, {
+                file: 'avc_settings.php',
+                template: '{{php}}',
+                values: {
+                    php: Object.keys(config.php).map(function (key) {
+                        return key + '=' + config.php[key];
+                    }).join('&')
+                }
+            }),
+            generate(null, {
+                file: 'avc_settings.asp',
+                template: '{{asp}}',
+                values: {
+                    asp: Object.keys(config.asp).map(function (key) {
+                        return key + '=' + config.asp[key];
+                    }).join('&')
+                }
+            }),
+            new Funnel(path.join(path.resolve(this.root, ''), 'public/'), {
+                srcDir: '/',
+                destDir: '/',
+                include: ['**/*.swf', '**/*.gif', '**/*.png', '**/*.jpg', '**/*.xml', '**/*.php']
+            })
+        ]);
+    }
 };
 
 
 var DEFAULT_OPTIONS = {
-  connectionstring: '',
+    connectionstring: '',
 
-  recorderId: '',
-  //languagefile:String
-  //description: path to the XML file containing words and phrases to be used in the video recorder interface, use this setting to switch between languages while maintaining several language files
-  //values: URL paths to the translation files
-  //default: 'translations/en.xml'
-  languagefile: 'translations/en.xml',
+    recorderId: '',
+    //languagefile:String
+    //description: path to the XML file containing words and phrases to be used in the video recorder interface, use this setting to switch between languages while maintaining several language files
+    //values: URL paths to the translation files
+    //default: 'translations/en.xml'
+    languagefile: 'translations/en.xml',
 
-  //qualityurl: String
-  //desc: path to the .xml file describing video and audio quality to use for recording, this variable has higher priority than the qualityurl flash var from the .html files
-  //values: URL paths to the audio/video quality profile files
-  //default: '' (in which case the qualityurl flash var is being used, it's found in the .html files embedding videorecorder.swf)
-  // qualityurl: '',
-  qualityurl: 'audio_video_quality_profiles/640x480x30x90.xml',
+    //qualityurl: String
+    //desc: path to the .xml file describing video and audio quality to use for recording, this variable has higher priority than the qualityurl flash var from the .html files
+    //values: URL paths to the audio/video quality profile files
+    //default: '' (in which case the qualityurl flash var is being used, it's found in the .html files embedding videorecorder.swf)
+    // qualityurl: '',
+    qualityurl: 'audio_video_quality_profiles/640x480x30x90.xml',
 
-  //maxRecordingTime: Number
-  //desc: the maximum recording time in seconds. If set to -1, the 'mrt' flash var parameter will be used, this way the maximum recording time can be set through this flash param specifically if needed.
-  //values: any number greater than 0 OR -1;
-  //default:120
-  maxRecordingTime: 120,
+    //maxRecordingTime: Number
+    //desc: the maximum recording time in seconds. If set to -1, the 'mrt' flash var parameter will be used, this way the maximum recording time can be set through this flash param specifically if needed.
+    //values: any number greater than 0 OR -1;
+    //default:120
+    maxRecordingTime: 120,
 
-  //userId: String
-  //desc: the id of the user logged into the website, not mandatory, this var is passed back to the save_video_to_db.php file via GET when the [SAVE] button in the recorder is pressed, this variable can also be passed via flash vars like this: videorecorder.swf?userId=XXX, but the value in this file, if not empty, takes precedence. If $config["useUserId"]="true", the value of this variable is also used in the stream name.
-  //values: strings or numbers will do
-  //by default its empty: ""
-  userId: '',
+    //userId: String
+    //desc: the id of the user logged into the website, not mandatory, this var is passed back to the save_video_to_db.php file via GET when the [SAVE] button in the recorder is pressed, this variable can also be passed via flash vars like this: videorecorder.swf?userId=XXX, but the value in this file, if not empty, takes precedence. If $config["useUserId"]="true", the value of this variable is also used in the stream name.
+    //values: strings or numbers will do
+    //by default its empty: ""
+    userId: '',
 
-  //outgoingBuffer: Number
-  //desc: Specifies how long the buffer for the outgoing audio/video data can grow before Flash Player starts dropping frames. On a high-speed connection, buffer time will not affect anything because data is sent almost as quickly as it is captured and there is no need to buffer it. On a slow connection, however, there might be a significant difference between how fast Flash Player can capture audio and video data data and how fast it can be sent to the client, thus the surplus needs to be buffered. HDFVR will increase the value specified here as much as possible (if the buffer fills more than 90% of the available buffer, we double the available buffer) to prevent Flash Player from dumping the data in the buffer when it's full.
-  //values: 30,60,etc...
-  //default:60
-  outgoingBuffer: 60,
+    //outgoingBuffer: Number
+    //desc: Specifies how long the buffer for the outgoing audio/video data can grow before Flash Player starts dropping frames. On a high-speed connection, buffer time will not affect anything because data is sent almost as quickly as it is captured and there is no need to buffer it. On a slow connection, however, there might be a significant difference between how fast Flash Player can capture audio and video data data and how fast it can be sent to the client, thus the surplus needs to be buffered. HDFVR will increase the value specified here as much as possible (if the buffer fills more than 90% of the available buffer, we double the available buffer) to prevent Flash Player from dumping the data in the buffer when it's full.
+    //values: 30,60,etc...
+    //default:60
+    outgoingBuffer: 60,
 
-  //playbackBuffer: Number
-  //desc: specifies how much video time (in seconds) to buffer when reviewing/playing the recorded video
-  //values: 1, 10,20,30,60,etc...
-  //default:1
-  playbackBuffer: 1,
+    //playbackBuffer: Number
+    //desc: specifies how much video time (in seconds) to buffer when reviewing/playing the recorded video
+    //values: 1, 10,20,30,60,etc...
+    //default:1
+    playbackBuffer: 1,
 
-  //autoPlay: String
-  //desc: weather the recorded video should play automatically after recording it or if HDFVR should  wait for the user to press the PLAY button
-  //values: false, true
-  //default: 'false'
-  autoPlay: 'false',
+    //autoPlay: String
+    //desc: weather the recorded video should play automatically after recording it or if HDFVR should  wait for the user to press the PLAY button
+    //values: false, true
+    //default: 'false'
+    autoPlay: 'false',
 
-  //deleteUnsavedFlv: String
-  //desc: whether the recorded videos for which the user has not pressed [SAVE] will be deleted from the media server or not
-  //values: false, true
-  //default: 'false'
-  deleteUnsavedFlv: 'false',
+    //deleteUnsavedFlv: String
+    //desc: whether the recorded videos for which the user has not pressed [SAVE] will be deleted from the media server or not
+    //values: false, true
+    //default: 'false'
+    deleteUnsavedFlv: 'false',
 
-  //hideSaveButton:Number
-  //desc: makes the [SAVE] button invisible. When the [SAVE] button is pressed the save_video_to_db.xxx script is called and the corresponding JS functions. The creation/existence of the new video file and corresponding snapshot do not depend on pressing this button.
-  //An invisible SAVE button can be used to move the SAVE action to the HTML page where there can be other form fields that can be submitted together with the info about the vid.
-  //When the SAVE button is hidden you can use the onUploadDone java script hook to get some info about the newly recorded flv file and redirect the user/enable a button on the HTML page/populate some hidden FORM vars/etc... .
-  //NOTE: when hiding this button some functions/calls will never be performed: save_video_to_db.php will never be called, onSaveOk and onSaveFailed JS functions will not be called
-  //Also see the autoSaveVideo variable which hides the button but stille xecuts the server side script
-  //values: 1 for hidden, 0 for visible
-  //default: 0 (visible)
-  hideSaveButton: 0,
+    //hideSaveButton:Number
+    //desc: makes the [SAVE] button invisible. When the [SAVE] button is pressed the save_video_to_db.xxx script is called and the corresponding JS functions. The creation/existence of the new video file and corresponding snapshot do not depend on pressing this button.
+    //An invisible SAVE button can be used to move the SAVE action to the HTML page where there can be other form fields that can be submitted together with the info about the vid.
+    //When the SAVE button is hidden you can use the onUploadDone java script hook to get some info about the newly recorded flv file and redirect the user/enable a button on the HTML page/populate some hidden FORM vars/etc... .
+    //NOTE: when hiding this button some functions/calls will never be performed: save_video_to_db.php will never be called, onSaveOk and onSaveFailed JS functions will not be called
+    //Also see the autoSaveVideo variable which hides the button but stille xecuts the server side script
+    //values: 1 for hidden, 0 for visible
+    //default: 0 (visible)
+    hideSaveButton: 0,
 
-  //onSaveSuccessURL:String
-  //desc: when the [SAVE] button is pressed (if it's enabled) save_video_to_db.php (or .asp) is called. If the save operation succeeds AND if this variable is NOT EMPTY, the user will be taken to the URL
-  //values: any URL you want the user directed to after he presses the [Save] button
-  //default: ""
-  onSaveSuccessURL: "",
+    //onSaveSuccessURL:String
+    //desc: when the [SAVE] button is pressed (if it's enabled) save_video_to_db.php (or .asp) is called. If the save operation succeeds AND if this variable is NOT EMPTY, the user will be taken to the URL
+    //values: any URL you want the user directed to after he presses the [Save] button
+    //default: ""
+    onSaveSuccessURL: "",
 
-  //snapshotSec:Number
-  //desc: the snapshot is taken when the recording reaches this length/time
-  //NOTE: THE SNAPSHOT IS SAVED TO THE WEB SERVER AS A JPG WHEN THE USER PRESSES THE SAVE BUTTON. If Save is not pressed the snapshot is not saved.
-  //values: any number  greater or equal to 0,  if 0 then the snap shot is taken when the [REC] button is pressed
-  //default: 5
-  snapshotSec: 5,
+    //snapshotSec:Number
+    //desc: the snapshot is taken when the recording reaches this length/time
+    //NOTE: THE SNAPSHOT IS SAVED TO THE WEB SERVER AS A JPG WHEN THE USER PRESSES THE SAVE BUTTON. If Save is not pressed the snapshot is not saved.
+    //values: any number  greater or equal to 0,  if 0 then the snap shot is taken when the [REC] button is pressed
+    //default: 5
+    snapshotSec: 5,
 
-  //snapshotEnable:Number
-  //desc: if set to true the recorder will take a snapshot
-  //values: true or false
-  //default: 'true'
-  snapshotEnable: "true",
+    //snapshotEnable:Number
+    //desc: if set to true the recorder will take a snapshot
+    //values: true or false
+    //default: 'true'
+    snapshotEnable: "true",
 
-  //minRecordTime:Number
-  //desc: the minimum number of seconds a recording must be in length. The STOP button will be disabled until the recording reaches this length!
-  //values: any number lower them maxRecordingTime
-  //default: 5
-  minRecordTime: 5,
+    //minRecordTime:Number
+    //desc: the minimum number of seconds a recording must be in length. The STOP button will be disabled until the recording reaches this length!
+    //values: any number lower them maxRecordingTime
+    //default: 5
+    minRecordTime: 5,
 
-  //backgroundColor:Hex number
-  //desc: color of background area inside the video recorder around the video area
-  //values: any color in hex format
-  //default:0x990000 (dark red)
-  backgroundColor: "0xf6f6f6",
+    //backgroundColor:Hex number
+    //desc: color of background area inside the video recorder around the video area
+    //values: any color in hex format
+    //default:0x990000 (dark red)
+    backgroundColor: "0xf6f6f6",
 
-  //menuColor:Hex number
-  //desc: the color of the lower area of the recorder containing the buttons and the scrub bar
-  //values:any color in hex format
-  //default:0x333333 (dark grey)
-  menuColor: "0xe9e9e9",
+    //menuColor:Hex number
+    //desc: the color of the lower area of the recorder containing the buttons and the scrub bar
+    //values:any color in hex format
+    //default:0x333333 (dark grey)
+    menuColor: "0xe9e9e9",
 
-  //radiusCorner:Number
-  //desc: the radius of the 4 corners of the video recorder
-  //values: 0 for no rounded corners, 4,8,16,etc...
-  //default: 16
-  radiusCorner: 8,
+    //radiusCorner:Number
+    //desc: the radius of the 4 corners of the video recorder
+    //values: 0 for no rounded corners, 4,8,16,etc...
+    //default: 16
+    radiusCorner: 8,
 
-  //showFps:String
-  //desc: Shows or hides the FPS counter
-  //values: 'false' to hide it 'true' to show it
-  //default: 'true'
-  showFps: 'false',
+    //showFps:String
+    //desc: Shows or hides the FPS counter
+    //values: 'false' to hide it 'true' to show it
+    //default: 'true'
+    showFps: 'false',
 
-  //recordAgain:String
-  //desc:if set to true the user will be able to record again and again until he is happy with the result. If set to false he only has 1 shot!
-  //values:'false' for one recording, 'true' for multiple recordings
-  //default: 'true'
-  recordAgain:  'true',
+    //recordAgain:String
+    //desc:if set to true the user will be able to record again and again until he is happy with the result. If set to false he only has 1 shot!
+    //values:'false' for one recording, 'true' for multiple recordings
+    //default: 'true'
+    recordAgain: 'true',
 
-  //useUserId:String
-  //desc:if set to 'true' the stream name will be {prefix}{userId}{timestamp_random} instead of {prefix}{timestamp_random}. {userId} will be reaplced by HDFVR with the value of $config['userId'] from this file.
-  //values:'false' for not using the userId in the file name, 'true' for using it
-  //default: 'false'
-  useUserId:  'true',
+    //useUserId:String
+    //desc:if set to 'true' the stream name will be {prefix}{userId}{timestamp_random} instead of {prefix}{timestamp_random}. {userId} will be reaplced by HDFVR with the value of $config['userId'] from this file.
+    //values:'false' for not using the userId in the file name, 'true' for using it
+    //default: 'false'
+    useUserId: 'true',
 
-  //streamPrefix:String
-  //desc: adds a prefix to the video file name on the media server like this: {prefix}{timestamp_random} or {prefix}{userId}{timestamp_random} if the useUserId option is set to true
-  //values: a string
-  //default: "videoStream_"
-  streamPrefix: "videoStream_",
+    //streamPrefix:String
+    //desc: adds a prefix to the video file name on the media server like this: {prefix}{timestamp_random} or {prefix}{userId}{timestamp_random} if the useUserId option is set to true
+    //values: a string
+    //default: "videoStream_"
+    streamPrefix: "videoStream_",
 
-  //streamName:String
-  //desc: By default the application generates a random name ({prefix}_{timestamp_random}) for the video file. If you want to use a certain name set this variable and it will overwrite the pattern {prefix}_{timestamp_random}. The stream extension (.flv , .mp4 or .f4v) should NOT be used in the stream name.
-  //values: a string
-  //default: ""
-  streamName: "",
+    //streamName:String
+    //desc: By default the application generates a random name ({prefix}_{timestamp_random}) for the video file. If you want to use a certain name set this variable and it will overwrite the pattern {prefix}_{timestamp_random}. The stream extension (.flv , .mp4 or .f4v) should NOT be used in the stream name.
+    //values: a string
+    //default: ""
+    streamName: "",
 
-  //disableAudio:String
-  //desc: By default the application records audio and video. If you want to disable audio recording set this var to 'true'.
-  //values: 'false' to include audio in the recording, 'true' to record without audio
-  //default: 'false'
-  disableAudio: 'false',
+    //disableAudio:String
+    //desc: By default the application records audio and video. If you want to disable audio recording set this var to 'true'.
+    //values: 'false' to include audio in the recording, 'true' to record without audio
+    //default: 'false'
+    disableAudio: 'false',
 
-  //chmodStreams:String
-  //desc: If you want to change the permissions on the newly recorded video file after it is saved to the disk on the media server you can use this variable. This works only on Red5 and Wowza.
-  //values: "0666","0777", etc.
-  //default: ""
-  chmodStreams: "",
+    //chmodStreams:String
+    //desc: If you want to change the permissions on the newly recorded video file after it is saved to the disk on the media server you can use this variable. This works only on Red5 and Wowza.
+    //values: "0666","0777", etc.
+    //default: ""
+    chmodStreams: "",
 
-  //countdownTimer:String
-  //desc: set to true if you want the timer to decrease from the upper limit (maxRecordingTime) down to 0
-  //values: "true", "false"
-  //defaut: "false"
-  countdownTimer: "false",
+    //countdownTimer:String
+    //desc: set to true if you want the timer to decrease from the upper limit (maxRecordingTime) down to 0
+    //values: "true", "false"
+    //defaut: "false"
+    countdownTimer: "false",
 
-  //overlayPath:String
-  //desc: relative URL path to the image to be shown as overlay
-  //values: any relative path
-  //default: "" //no overlay
-  overlayPath: "",
+    //overlayPath:String
+    //desc: relative URL path to the image to be shown as overlay
+    //values: any relative path
+    //default: "" //no overlay
+    overlayPath: "",
 
-  //overlayPosition:String
-  //desc: position of the overlay image mentioned above
-  //values: "tr" for top right, "tl" for top left and "cen" for centered, no other positions are supported
-  //default: "tr"
-  overlayPosition: "tr",
+    //overlayPosition:String
+    //desc: position of the overlay image mentioned above
+    //values: "tr" for top right, "tl" for top left and "cen" for centered, no other positions are supported
+    //default: "tr"
+    overlayPosition: "tr",
 
-  //loopbackMic:String
-  //desc: whether or not the sound should be also played back in the speakers/heaphones during recording
-  //values: "true" for yes, "false" for no
-  //default: "false"
-  loopbackMic: "false",
+    //loopbackMic:String
+    //desc: whether or not the sound should be also played back in the speakers/heaphones during recording
+    //values: "true" for yes, "false" for no
+    //default: "false"
+    loopbackMic: "false",
 
-  //showMenu:String
-  //desc: whether or not the bottom menu in the HDFVR shoud show, some people choose to control the HDFVR via JS and they do ot need the menu, when not using the menu you can decrease the height of HDFVR by 32 (3o is the height of the button 2 is the default padding value in this config file)
-  //values: "true" to show, "false" to hide
-  //default: "true"
-  showMenu: "true",
+    //showMenu:String
+    //desc: whether or not the bottom menu in the HDFVR shoud show, some people choose to control the HDFVR via JS and they do ot need the menu, when not using the menu you can decrease the height of HDFVR by 32 (3o is the height of the button 2 is the default padding value in this config file)
+    //values: "true" to show, "false" to hide
+    //default: "true"
+    showMenu: "true",
 
-  //showTimer:String
-  //desc: Show or hides the timer
-  //values: 'false' to hide it 'true' to show it
-  //default: 'true'
-  showTimer: 'true',
+    //showTimer:String
+    //desc: Show or hides the timer
+    //values: 'false' to hide it 'true' to show it
+    //default: 'true'
+    showTimer: 'true',
 
-  //showSoundBar:String
-  //desc: Shows or hides the sound bar
-  //values: 'false' to hide it 'true' to show it
-  //default: 'true'
-  showSoundBar: 'true',
+    //showSoundBar:String
+    //desc: Shows or hides the sound bar
+    //values: 'false' to hide it 'true' to show it
+    //default: 'true'
+    showSoundBar: 'true',
 
-  //flipImageHorizontally: String
-  //desc: When set to 'false' HDFVR will show the webcam feed exactly as it comes from the webcam (direct mode). When set to 'true' HDFVR shows the webcam feed (while recording and reviewing the recorded video, the actual video file will not be flipped) flipped horizontally, in a similar way to a mirror or the iPhone's front facing camera.
-  //values: 'true' to flip it (mirror mode), 'false' to show the feed as it comes from the webcam (direct mode)
-  //default: 'false'
-  flipImageHorizontally: 'false',
+    //flipImageHorizontally: String
+    //desc: When set to 'false' HDFVR will show the webcam feed exactly as it comes from the webcam (direct mode). When set to 'true' HDFVR shows the webcam feed (while recording and reviewing the recorded video, the actual video file will not be flipped) flipped horizontally, in a similar way to a mirror or the iPhone's front facing camera.
+    //values: 'true' to flip it (mirror mode), 'false' to show the feed as it comes from the webcam (direct mode)
+    //default: 'false'
+    flipImageHorizontally: 'false',
 
-  //hidePlayButton:Number
-  //desc: This controls whether or not the play/pause button is visible in the controls menu of HDFVR
-  //values: 1 for hidden, 0 for visible
-  //default: 0 (visible)
-  hidePlayButton: 1,
+    //hidePlayButton:Number
+    //desc: This controls whether or not the play/pause button is visible in the controls menu of HDFVR
+    //values: 1 for hidden, 0 for visible
+    //default: 0 (visible)
+    hidePlayButton: 1,
 
-  //enablePauseWhileRecording:Number
-  //desc: This controls whether or not HDFVR can be paused/resumed during a recording. Pausing the video on Red5 1.0.2 is known to cause issues with the consistency of the final recording produced
-  //values: 1 for enabled, 0 for disabled
-  //default: 0 (disabled)
-  enablePauseWhileRecording: 1,
+    //enablePauseWhileRecording:Number
+    //desc: This controls whether or not HDFVR can be paused/resumed during a recording. Pausing the video on Red5 1.0.2 is known to cause issues with the consistency of the final recording produced
+    //values: 1 for enabled, 0 for disabled
+    //default: 0 (disabled)
+    enablePauseWhileRecording: 1,
 
-  //enableBlinkingRec:Number
-  //desc: This controls whether or not HDFVR will display the Rec blinking animation while recording
-  //values: 1 for enabled, 0 for disabled
-  //default: 1 (enabled)
-  enableBlinkingRec: 1,
+    //enableBlinkingRec:Number
+    //desc: This controls whether or not HDFVR will display the Rec blinking animation while recording
+    //values: 1 for enabled, 0 for disabled
+    //default: 1 (enabled)
+    enableBlinkingRec: 1,
 
-  //microphoneGain:Number
-  //desc: This controls the amount by which the microphone boosts the signal. Although this value is applied and reflects the recording level, the setting does not update Flash Player's  "Record Volume" slider in Flash Player Settings > Microphone. This seems to be a bug in Flash Player.
-  //values: 0 to 100
-  //default: 50
-  microphoneGain: 50,
+    //microphoneGain:Number
+    //desc: This controls the amount by which the microphone boosts the signal. Although this value is applied and reflects the recording level, the setting does not update Flash Player's  "Record Volume" slider in Flash Player Settings > Microphone. This seems to be a bug in Flash Player.
+    //values: 0 to 100
+    //default: 50
+    microphoneGain: 50,
 
-  //allowAudioOnlyRecording:Number
-  //desc: This controls whether or not HDFVR is permitted to record audio only when a webcam is missing and only a microphone is detected.
-  //values:1 for enabled, 0 for disabled
-  //default: 1 (enabled)
-  allowAudioOnlyRecording: 0,
+    //allowAudioOnlyRecording:Number
+    //desc: This controls whether or not HDFVR is permitted to record audio only when a webcam is missing and only a microphone is detected.
+    //values:1 for enabled, 0 for disabled
+    //default: 1 (enabled)
+    allowAudioOnlyRecording: 0,
 
-  //enableFFMPEGConverting:Number
-  //desc: This controls whether or not HDFVR will trigger server side the execution of FFMPEG converting once the stream finished uploading.
-  //values:1 for enabled, 0 for disabled
-  //default: 0 (disabled)
-  enableFFMPEGConverting: 0,
+    //enableFFMPEGConverting:Number
+    //desc: This controls whether or not HDFVR will trigger server side the execution of FFMPEG converting once the stream finished uploading.
+    //values:1 for enabled, 0 for disabled
+    //default: 0 (disabled)
+    enableFFMPEGConverting: 0,
 
-  //ffmpegCommand:String
-  //desc: This sets the conversion command that will be executed with FFMPEG when enableFFMPEGConverting is set to 1. The command has the following pattern: "ffmpeg -i [THE_INPUT_FLV_FILE]  [codec parameters audio/video] [THE_OUTPUT_MP4_FILE]" . The [THE_INPUT_FLV_FILE] and [THE_OUTPUT_MP4_FILE] parts must not be changed, both the path to ffmpeg and to the video files will be detected and set automatically by the media server. Only the codec parameters will be taken into account. The command is expressed like this to put it more into context as opposed to just sending the codec parameters.
-  //values:Example command: ffmpeg -i [THE_INPUT_FLV_FILE] -c:v libx264 [THE_OUTPUT_MP4_FILE]
-  //default: ffmpeg -i [THE_INPUT_FLV_FILE] -c:v libx264 [THE_OUTPUT_MP4_FILE]
-  ffmpegCommand: "ffmpeg -i [THE_INPUT_FLV_FILE] -c:v libx264 [THE_OUTPUT_MP4_FILE]",
+    //ffmpegCommand:String
+    //desc: This sets the conversion command that will be executed with FFMPEG when enableFFMPEGConverting is set to 1. The command has the following pattern: "ffmpeg -i [THE_INPUT_FLV_FILE]  [codec parameters audio/video] [THE_OUTPUT_MP4_FILE]" . The [THE_INPUT_FLV_FILE] and [THE_OUTPUT_MP4_FILE] parts must not be changed, both the path to ffmpeg and to the video files will be detected and set automatically by the media server. Only the codec parameters will be taken into account. The command is expressed like this to put it more into context as opposed to just sending the codec parameters.
+    //values:Example command: ffmpeg -i [THE_INPUT_FLV_FILE] -c:v libx264 [THE_OUTPUT_MP4_FILE]
+    //default: ffmpeg -i [THE_INPUT_FLV_FILE] -c:v libx264 [THE_OUTPUT_MP4_FILE]
+    ffmpegCommand: "ffmpeg -i [THE_INPUT_FLV_FILE] -c:v libx264 [THE_OUTPUT_MP4_FILE]",
 
-  //autoSave:Number
-  //desc: This controls whether or not HDFVR will automatically call the save_video_to_db script, having the same effect as pressing the [SAVE] button in menu. To eliminate the issue of double entries in the database, enabling this setting will automatically hide the [SAVE] button.
-  //values:1 for enabled, 0 for disabled
-  //default: 1 (enabled)
-  autoSave: 1,
+    //autoSave:Number
+    //desc: This controls whether or not HDFVR will automatically call the save_video_to_db script, having the same effect as pressing the [SAVE] button in menu. To eliminate the issue of double entries in the database, enabling this setting will automatically hide the [SAVE] button.
+    //values:1 for enabled, 0 for disabled
+    //default: 1 (enabled)
+    autoSave: 1,
 
-  //payload: String
-  //desc: The payload var is used to transmit data in the form of strings or JSON encoded string, not mandatory, this var is passed back to the save_video_to_db.php file via GET when the [SAVE] button in the recorder is pressed, this variable can also be passed via flash vars like this: videorecorder.swf?payload=XXX.
-  //values: strings, numbers, JSON encoded strings
-  //by default its empty: ""
-  payload: '',
+    //payload: String
+    //desc: The payload var is used to transmit data in the form of strings or JSON encoded string, not mandatory, this var is passed back to the save_video_to_db.php file via GET when the [SAVE] button in the recorder is pressed, this variable can also be passed via flash vars like this: videorecorder.swf?payload=XXX.
+    //values: strings, numbers, JSON encoded strings
+    //by default its empty: ""
+    payload: '',
 
-  //normalColor:Hex number
-  //desc: color of the text and icons
-  //values: any color in hex format
-  //default:0x333333
-  normalColor: "0x334455",
+    //normalColor:Hex number
+    //desc: color of the text and icons
+    //values: any color in hex format
+    //default:0x333333
+    normalColor: "0x334455",
 
-  //overColor:Hex number
-  //desc: color applied to text and icons on mouse over
-  //values: any color in hex format
-  //default:0xdf8f90 (dark red)
-  overColor: "0x556677",
+    //overColor:Hex number
+    //desc: color applied to text and icons on mouse over
+    //values: any color in hex format
+    //default:0xdf8f90 (dark red)
+    overColor: "0x556677",
 
-  //skipInitialScreen:Number
-  //desc: If this settings is enabled HDFVR won't show the initial pre-recording screen introduced in HDFVR 2.0
-  //values: 1 for enabled, 0 for disabled
-  //default:0 (disabled)
-  skipInitialScreen: 0,
+    //skipInitialScreen:Number
+    //desc: If this settings is enabled HDFVR won't show the initial pre-recording screen introduced in HDFVR 2.0
+    //values: 1 for enabled, 0 for disabled
+    //default:0 (disabled)
+    skipInitialScreen: 0,
 
-  //hideDeviceSettingsButtons:Number
-  //desc: If this settings is enabled HDFVR won't display the camera and microphone settings buttons when the showMenu
-  // setting is set to FALSE. This is especially helpful if you are integrating HDFVR on a platform that will use the same hardware specifications and no changing of the devices will be needed.
-  //values: 1 for enabled, 0 for disabled
-  //default:0 (disabled)
-  hideDeviceSettingsButtons: 0,
+    //hideDeviceSettingsButtons:Number
+    //desc: If this settings is enabled HDFVR won't display the camera and microphone settings buttons when the showMenu
+    // setting is set to FALSE. This is especially helpful if you are integrating HDFVR on a platform that will use the same hardware specifications and no changing of the devices will be needed.
+    //values: 1 for enabled, 0 for disabled
+    //default:0 (disabled)
+    hideDeviceSettingsButtons: 0,
 
-  proxyType: null
+    proxyType: null
 };

--- a/exp-player/index.js
+++ b/exp-player/index.js
@@ -9,6 +9,22 @@ var BroccoliMergeTrees = require('broccoli-merge-trees');
 module.exports = {
     name: 'exp-player',
 
+    config(env, baseConfig) {
+        // Set default configuration to merge into the consuming application.
+        // TODO: This keeps consuming apps from breaking outright, but if you override one you need to override all.
+        // In the future we should implement, eg, initializers. Many of these current flags are ISP-specific.
+        return {
+            featureFlags: {
+                // Whether to load existing expData into the exp-frames
+                loadData: true,
+                // Whether to validate survey forms
+                validate: true,
+                // Whether to redirect users who have already taken the study to an error page
+                // Set to false to test study multiple times with the same account
+                showStudyCompletedPage: true
+            }
+        }
+    },
 
     isDevelopingAddon: function () {
         return true;


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-248
Companion to: TBD

# Purpose
If a user leaves a study early, capture event information.

# Summary of changes
- Add some default feature flag settings to `config()` for addon, so that non-ISP apps don't break when trying to consume code intended for ISP.
- Add flags/timing events for early exit so a record is saved in the session (see testing notes)
  - When user hits F1 key
  - When user leaves the page manually via back button, eg beforeunload events
- Minor code reformatting and cleanup

# Testing notes
## Sample of expected data
This adds a new field, `globalEventTimings`, to the attributes section of a session payload.

Any attempt to exit the study early should yield an `exitEarly` eventType. The type of the exit can be either:
- *browserNavigationAttempt*: Back button, close window, etc.
- *manualInterrupt*: The user elects to interrupt the study manually (eg by pressing the F1 key), such that they will be taken to the exit survey screen before leaving.

```
    "attributes": {
      ...
      "globalEventTimings": [
        {
          "exitType": "browserNavigationAttempt",
          "eventType": "exitEarly",
          "timestamp": "2016-10-14T18:42:04.341Z",
          "lastPageSeen": 7
        },
        {
          "exitType": "manualInterrupt",
          "eventType": "exitEarly",
          "timestamp": "2016-10-14T18:42:12.225Z",
          "lastPageSeen": 7
        }
      ],
    ...
```

## Testing procedure/ behavior
To test this, do various things, then look at the session payload generated at each step. (send a GET request with appropriate token to the session record URL of the form `https://the-server.com/v1/id/documents/experimenter.session<exptId>.<sessionId>`). You can get that URL by looking at the network tab- during an experiment, the browser sends PATCH requests to this URL.

1.  Participate in an experiment. At the consent screen (before recording a video), click the back button to navigate away.
  - Click "stay" to stay on the page. A `browserNavigationAttempt` exitEarly event should be logged.
  - Click the back button again, and then click "leave". A second `browserNavigationAttempt` will be logged with a more recent timestamp, and then you will actually be taken away from the page. 
2. Do the above- but instead of clicking the back button, quit the entire browser instead. A `browserNavigationAttempt` should be logged.
3. Participate in another experiment. At the consent screen, press `F1` (or `fn+F1` on a Mac, as appropriate). Whether you exit before or after filling out the survey, an exitType `manualInterrupt` should be captured.
4. Participate in an experiment. Attempt to leave, stay, then press F1. You should get one event of each exit type, the newest (successful) coming last.
5. Try the above in both Chrome and Firefox

## Caveats
Browser makers are making it progressively harder to interrupt any attempt to leave the page. (because of malicious sites that try to abuse the power to keep people there) We log the *attempt* to leave because we can not always determine whether the attempt is successful.

The logging event is done synchronously- the page should not be able to leave until the save is complete. It is possible, though unlikely, that a browser could decide to interrupt even synchronous usages in the future.