### PR TITLE
Improve log and exit experience when user exits study due to video issues

### DIFF
--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -68,7 +68,7 @@ export default Ember.Component.extend(FullScreen, {
             //   we are limited in our ability to prevent willful exits
             this.send('setGlobalTimeEvent', 'exitEarly', {
                 exitType: 'browserNavigationAttempt', // Page navigation, closed browser, etc
-                lastPageSeen: this.get('frameIndex') + 1
+                lastPageSeen: this.get('frameIndex')
             });
             //Ensure sync - try to force save to finish before exit
             Ember.run(() => this.get('session').save());

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -64,7 +64,6 @@ able to continue the study.
             return null;
         });
         $(window).on('keyup', (e) => {
-            console.log(e.which);
             if (e.which === 112) {
                 this.send('exitEarly');
             }

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -138,7 +138,6 @@ able to continue the study.
     },
     _exit() {
         this.send('sessionCompleted');
-        console.log(`Next: Saving session then redirecting to ${this.get('experiment.exitUrl') || '/'}`);
         this.get('session').save().then(() => window.location = this.get('experiment.exitUrl') || '/');
     },
 
@@ -161,7 +160,6 @@ able to continue the study.
 
         saveFrame(frameId, frameData) {
             // Save the data from a completed frame to the session data item
-            console.log(`SaveFrame: Saving frame data for ${frameId}`, frameData);
             this.get('session.sequence').push(frameId);
             this.get('session.expData')[frameId] = frameData;
             //TODO Implement diff PATCHing
@@ -169,10 +167,8 @@ able to continue the study.
         },
 
         next() {
-            console.log('next');
             var frameIndex = this.get('frameIndex');
             if (frameIndex < (this.get('frames').length - 1)) {
-                console.log(`Next: Transitioning to frame ${frameIndex + 1}`);
                 this._transition();
                 this.set('frameIndex', frameIndex + 1);
                 this.set('framePage', 0);
@@ -182,11 +178,8 @@ able to continue the study.
         },
 
         skipone() {
-            console.log('skip one frame');
-
             var frameIndex = this.get('frameIndex');
             if (frameIndex < (this.get('frames').length - 2)) {
-                console.log(`Next: Transitioning to frame ${frameIndex + 2}`);
                 this._transition();
                 this.set('frameIndex', frameIndex + 2);
                 return;
@@ -195,15 +188,10 @@ able to continue the study.
         },
 
         previous() {
-            console.log('previous');
-
             var frameIndex = this.get('frameIndex');
             if (frameIndex !== 0) {
-                console.log(`Previous: Transitioning to frame ${frameIndex - 1}`);
                 this._transition();
                 this.set('frameIndex', frameIndex - 1);
-            } else {
-                console.log('Previous: At frame 0');
             }
         },
 

--- a/exp-player/addon/components/exp-video-physics.js
+++ b/exp-player/addon/components/exp-video-physics.js
@@ -43,55 +43,6 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
 
     showVideoWarning: false,
 
-    videoSources: Ember.computed('isPaused', 'currentTask', 'useAlternate', function() {
-        if (this.get('isPaused')) {
-            return this.get('attnSources');
-        } else {
-            switch (this.get('currentTask')) {
-                case 'announce':
-                    return this.get('attnSources');
-                case 'intro':
-                    return this.get('introSources');
-                case 'test':
-                    if (this.get('useAlternate')) {
-                        return this.get('altSources');
-                    } else {
-                        return this.get('sources');
-                    }
-            }
-        }
-        return [];
-    }),
-
-    shouldLoop: Ember.computed('videoSources', function() {
-        return (this.get('isPaused') || (this.get('currentTask') === 'announce' || this.get('currentTask') === 'test'));
-    }),
-
-    onFullscreen: function() {
-        if (this.get('isDestroyed')) {
-            return;
-        }
-        this._super(...arguments);
-        if (!this.checkFullscreen()) {
-            this.sendTimeEvent('leftFullscreen');
-            if (!this.get('isPaused')) {
-                this.pauseStudy();
-            }
-        } else {
-            this.sendTimeEvent('enteredFullscreen');
-        }
-    },
-
-    sendTimeEvent(name, opts = {}) {
-        var streamTime = this.get('recorder') ? this.get('recorder').getTime() : null;
-
-        Ember.merge(opts, {
-            streamTime: streamTime,
-            videoId: this.get('videoId')
-        });
-        this.send('setTimeEvent', `exp-physics:${name}`, opts);
-    },
-
     meta: {
         name: 'Video player',
         description: 'Component that plays a video',
@@ -170,8 +121,58 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
             required: []
         }
     },
+
+    videoSources: Ember.computed('isPaused', 'currentTask', 'useAlternate', function() {
+        if (this.get('isPaused')) {
+            return this.get('attnSources');
+        } else {
+            switch (this.get('currentTask')) {
+                case 'announce':
+                    return this.get('attnSources');
+                case 'intro':
+                    return this.get('introSources');
+                case 'test':
+                    if (this.get('useAlternate')) {
+                        return this.get('altSources');
+                    } else {
+                        return this.get('sources');
+                    }
+            }
+        }
+        return [];
+    }),
+
+    shouldLoop: Ember.computed('videoSources', function() {
+        return (this.get('isPaused') || (this.get('currentTask') === 'announce' || this.get('currentTask') === 'test'));
+    }),
+
+    onFullscreen() {
+        if (this.get('isDestroyed')) {
+            return;
+        }
+        this._super(...arguments);
+        if (!this.checkFullscreen()) {
+            this.sendTimeEvent('leftFullscreen');
+            if (!this.get('isPaused')) {
+                this.pauseStudy();
+            }
+        } else {
+            this.sendTimeEvent('enteredFullscreen');
+        }
+    },
+
+    sendTimeEvent(name, opts = {}) {
+        var streamTime = this.get('recorder') ? this.get('recorder').getTime() : null;
+
+        Ember.merge(opts, {
+            streamTime: streamTime,
+            videoId: this.get('videoId')
+        });
+        this.send('setTimeEvent', `exp-physics:${name}`, opts);
+    },
+
     actions: {
-        showWarning: function() {
+        showWarning() {
             if (!this.get('showVideoWarning')) {
                 this.set('showVideoWarning', true);
                 this.sendTimeEvent('webcamNotConfigured');
@@ -183,14 +184,14 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
                 });
             }
         },
-        removeWarning: function() {
+        removeWarning() {
             this.set('showVideoWarning', false);
             this.get('recorder').hide();
             this.send('showFullscreen');
             this.pauseStudy();
         },
 
-        stopVideo: function() {
+        stopVideo() {
             var currentTask = this.get('currentTask');
             if (this.get('testTime') >= this.get('testLength')) {
                 this.send('_afterTest');
@@ -207,7 +208,7 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
             }
         },
 
-        playNext: function() {
+        playNext() {
             if (this.get("currentTask") === "intro") {
                 this.set("currentTask", "test");
             } else {
@@ -222,7 +223,7 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
             this.send('playNext');
         },
 
-        setTestTimer: function() {
+        setTestTimer() {
             window.clearInterval(this.get('testTimer'));
             this.set('testTime', 0);
             this.set('_lastTime', 0);
@@ -244,7 +245,7 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
             }, 100));
         },
 
-        startVideo: function() {
+        startVideo() {
             if (this.get('doingTest')) {
                 if (!this.get('hasCamAccess')) {
                     this.pauseStudy(true);
@@ -265,7 +266,7 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
                 }
             }
         },
-        startIntro: function() {
+        startIntro() {
             if (this.get('skip')) {
                 this.send('next');
                 return;
@@ -295,7 +296,7 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
         }
     },
 
-    pauseStudy: function(pause) { // only called in FS mode
+    pauseStudy(pause) { // only called in FS mode
         if (this.get('showVideoWarning')) {
             return;
         }

--- a/exp-player/addon/components/exp-video-physics.js
+++ b/exp-player/addon/components/exp-video-physics.js
@@ -176,6 +176,12 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
             if (!this.get('showVideoWarning')) {
                 this.set('showVideoWarning', true);
                 this.sendTimeEvent('webcamNotConfigured');
+
+                // If webcam error, save the partial frame payload immediately, so that we don't lose timing events if
+                // the user is unable to move on.
+                // TODO: Assumption: this assumes the user isn't resuming this experiment later, so partial data is ok.
+                this.send('save');
+
                 var recorder = this.get('recorder');
                 recorder.show();
                 recorder.on('onCamAccessConfirm', () => {

--- a/exp-player/addon/components/exp-video-physics.js
+++ b/exp-player/addon/components/exp-video-physics.js
@@ -397,6 +397,7 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
 
         this.sendTimeEvent('destroyingElement');
         this._super(...arguments);
+        // Todo: make removal of event listener more specific (in case a frame comes between the video and the exit survey)
         $(document).off("keyup");
     }
 });

--- a/exp-player/addon/components/exp-video-physics.js
+++ b/exp-player/addon/components/exp-video-physics.js
@@ -274,7 +274,7 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
             this.set('currentTask', 'intro');
             this.set('playAnnouncementNow', false);
 
-            if (~this.get('isPaused')) {
+            if (!this.get('isPaused')) {
                 if (this.isLast) {
                     this.send('next');
                 } else {
@@ -350,11 +350,12 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
 
     didInsertElement() {
         this._super(...arguments);
-        $(document).on("keyup", (e) => {
+        $(document).on('keyup', (e) => {
             if (this.checkFullscreen()) {
                 if (e.which === 32) { // space
                     this.pauseStudy();
-                } else if (e.which === 112) { // F1
+                } else if (e.which === 112) { // F1: exit the study early
+                    // FIXME: This binding does not seem to fire, likely because it is removed in willDestroy, called when exp-player advances to a new frame
                     if (this.get('recorder')) {
                         this.get('recorder').stop();
                     }
@@ -387,6 +388,12 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
         this.send('showFullscreen');
     },
     willDestroyElement() { // remove event handler
+        // Whenever the component is destroyed, make sure that event handlers are removed and video recorder is stopped
+        if (this.get('recorder')) {
+            this.get('recorder').hide(); // Hide the webcam config screen
+            this.get('recorder').stop();
+        }
+
         this.sendTimeEvent('destroyingElement');
         this._super(...arguments);
         $(document).off("keyup");

--- a/exp-player/addon/services/video-recorder.js
+++ b/exp-player/addon/services/video-recorder.js
@@ -69,11 +69,7 @@ const VideoRecorder = Ember.Object.extend({
         return window.swfobject.getObjectById(this.get('_SWFId'));
     }).volatile(),
 
-    install({
-        record: record
-    } = {
-        record: false
-    }) {
+    install({ record: record } = { record: false }) {
         this.set('divId', `${this.get('divId')}-${this.get('recorderId')}`);
 
         var $element = $(this.get('element'));
@@ -212,7 +208,9 @@ const VideoRecorder = Ember.Object.extend({
     // Stop recording and save the video to the server
     stop({ destroy: destroy } = { destroy: false }) {
         // Force at least 1.5 seconds of video to be recorded. Otherwise upload is never called
-        if (1.5 - this.getTime() > 0) {
+        // We optimistically start the connection before checking for camera access. For now, let recorder stop
+        // immediately if recorder never had camera access- the video would be meaningless anyway
+        if (this.get('hasCamAccess') && (1.5 - this.getTime() > 0)) {
             window.setTimeout(this.stop.bind(this, {
                 destroy: destroy
             }), 1.5 - this.getTime());

--- a/exp-player/addon/services/video-recorder.js
+++ b/exp-player/addon/services/video-recorder.js
@@ -223,6 +223,8 @@ const VideoRecorder = Ember.Object.extend({
                     try {
                         recorder.stopVideo();
                     } catch (e) {
+                        // TODO: Under some conditions there is no stopVideo method- can we do a better job of
+                        //  identifying genuine errors?
                     }
                     this.set('_recording', false);
                 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-265
Companion to: 

## Purpose
Fix an issue where user could not see the exit survey if they attempted to leave during the "fix camera configuration" screen.

Also, log event timings for these events. This entails saving *partial* frame payloads if a user has to exit early. This will require some internal refactoring to support the ISP use case on the shared platform, followed by a round of internal refactoring.

## Summary of changes
- [x] Make sure "fix video issues" screen is hidden if user goes straight to the exit survey. Previously, player event handler was stomping over the event handler for the frame.
- [x] Make sure that video frame payloads are immediately saved to the server any time that the showWarning event is called. This improves our odds of knowing there were video problems.

## Testing notes
### Creating a more favorable environment for testing
 If you remove the "remember me" setting, it's much easier to see camera issues. (Lookit doesn't work *unless* "remember me" is selected)

To generate some test data for the target problems:
Make the browser forget authorization to access camera (must approve both browser and flash plugin settings). Authorize for the consent screen, but don't click remember me. Go to first video, authorize camera access when it interrupts. Let second video play. This time when it interrupts, press F1 to go to exit survey.

### Before and after: things to test
#### Miscellaneous
- [x] When the "it looks like there was a problem with your webcam" video configuration screen comes up during an experiment, do not authorize access, and press F1. Confirm that you are able to see the study details.
- [x] When "global early exit" timing events are sent, make sure the last frame seen corresponds to the name of the frame in the payload (eg 0 vs 1 based counting)

#### Changes to server payload
- [x] Before the change, if you got a video configuration screen, no data from that frame was saved to the server. After the change, the server payload should contain a key in `expData` for that frame, up to the "webcamnotconfigured"/ "pausevideo" timing events.


#### Changes to video
- The video shouldn't change, but there were some tweaks made to the start/stop process. Wait several minutes for the experiment to finish (to let the server do its work), then verify that:
  - [x] We should still see a correctly formed video for the frame on which access was granted.
  - [x] For the frame where no video access was granted, it should look the same after the change as before.
