### PR TITLE
Refactor player to extract Lookit-specific exit behaviors

### DIFF
--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -54,8 +54,11 @@ export default Ember.Component.extend(FullScreen, {
 
     /**
      * Customize what happens when the user exits the page
+     * @method beforeUnload
+     * @parameter {event} event The event to be handled
+     * @returns {String|null} If string is provided, triggers a modal to confirm user wants to leave page
      */
-    beforeUnload(e) {
+    beforeUnload(event) {
         if (!this.get('allowExit')) {
             this.set('hasAttemptedExit', true);
             this.send('exitFullscreen');
@@ -73,7 +76,7 @@ export default Ember.Component.extend(FullScreen, {
             // Then attempt to warn the user and exit
             // Newer browsers will ignore the custom message below. See https://bugs.chromium.org/p/chromium/issues/detail?id=587940
             const message = this.get('messageEarlyExitModal');
-            e.returnValue = message;
+            event.returnValue = message;
             return message;
         }
         return null;

--- a/exp-player/addon/components/exp-player.js
+++ b/exp-player/addon/components/exp-player.js
@@ -46,6 +46,11 @@ export default Ember.Component.extend(FullScreen, {
     allowExit: false,
     hasAttemptedExit: false,
 
+    /**
+     * The message to display in the early exit modal. Newer browsers may not respect this message.
+     * @property {String|null} messageEarlyExitModal
+     */
+    messageEarlyExitModal: 'Are you sure you want to leave this page? You may lose unsaved data.',
 
     /**
      * Customize what happens when the user exits the page
@@ -66,22 +71,8 @@ export default Ember.Component.extend(FullScreen, {
             Ember.run(() => this.get('session').save());
 
             // Then attempt to warn the user and exit
-            let toast = this.get('toast');
-            toast.warning('To leave the study early, press F1 and then select a privacy level for your videos');
             // Newer browsers will ignore the custom message below. See https://bugs.chromium.org/p/chromium/issues/detail?id=587940
-            const message = `
-If you're sure you'd like to leave this study early
-you can do so now.
-
-We'd appreciate it if before you leave you fill out a
-very brief exit survey letting us know how we can use
-any video captured during this session. Press 'Stay on
-this Page' and you will be prompted to go to this
-exit survey.
-
-If leaving this page was an accident you will be
-able to continue the study.
-`;
+            const message = this.get('messageEarlyExitModal');
             e.returnValue = message;
             return message;
         }


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-267
Companion to: 

## Purpose
The player currently has certain custom behaviors that are Lookit-specific. We do not, for example, want ISP users to be able to skip to the last frame by pressing F1.

Refactor to move those behaviors inside lookit.

## Summary of changes
- Reorg code: move lookit-only functionality into Lookit.
- Add a new `beforeUnload` hook to the player, controlling additional custom behavior that happens when a user leaves. For example, it can be used to display a toast message with more info
- Add a new `messageEarlyExitModal` property, controlling text of the confirm-on-exit modal. (may not show this text in all browser, but method has to return a non-null value if you want the modal to appear)

## Testing notes
- All studies will show warning messages with unsaved data by default 
- ISP will not respond to the F1 key
- Lookit will respond to the F1 key by skipping ahead to the last frame