### PR TITLE
Feature: Add question asking what time situation occurred [LEI-262]

### DIFF
--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -50,9 +50,13 @@ export default ExpFrameBaseComponent.extend(Validations, {
     }),
     times: Ember.computed(function() {
         var times = [];
-        for (var i=0; i < 24; i++) {
+        for (var i=0; i <= 24; i++) {
             var date = new Date(2016, 10, 17, i, 0, 0);
-            // TODO: Handle missing moment locales: amharic, urdu, runyakore, luganda,             longDateFormat : {
+            var locale = this.get('i18n.locale');
+            if (locale in config.localeTimeFormats) {
+                // Add locale information not specified by moment.js
+                moment.updateLocale(locale, config.localeTimeFormats[locale])
+            }
             moment.locale(this.get('i18n.locale'));
             times.push(moment(date).format('LT'));
         }

--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -3,6 +3,7 @@ import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
 import layout from './template';
 import {validator, buildValidations} from 'ember-cp-validations';
 import config from 'ember-get-config';
+import moment from 'moment';
 
 
 function getLength(value) {
@@ -21,7 +22,8 @@ var presence = validator('presence', {
 const Validations = buildValidations({
     q1: presence,
     q2: presence,
-    q3: presence
+    q3: presence,
+    q4: presence
 });
 
 export default ExpFrameBaseComponent.extend(Validations, {
@@ -46,12 +48,24 @@ export default ExpFrameBaseComponent.extend(Validations, {
         message = message.replace("0", length.toString());
         return message;
     }),
+    times: Ember.computed(function() {
+        var times = [];
+        for (var i=0; i < 24; i++) {
+            var date = new Date(2016, 10, 17, i, 0, 0);
+            // TODO: Handle missing moment locales: amharic, urdu, runyakore, luganda,             longDateFormat : {
+            moment.locale(this.get('i18n.locale'));
+            times.push(moment(date).format('LT'));
+        }
+        return times;
+    }),
+    q4: null,
 
-    responses: Ember.computed('q1', 'q2', 'q3', function() {
+    responses: Ember.computed('q1', 'q2', 'q3', 'q4', function() {
         return {
             q1: this.get('q1'),
             q2: this.get('q2'),
-            q3: this.get('q3')
+            q3: this.get('q3'),
+            q4: this.get('q4')
         };
     }),
 
@@ -85,6 +99,9 @@ export default ExpFrameBaseComponent.extend(Validations, {
                         },
                         q3: {
                             type: 'string'
+                        },
+                        q4: {
+                            type: 'string'
                         }
                     }
                 }
@@ -103,5 +120,6 @@ export default ExpFrameBaseComponent.extend(Validations, {
         this.set('q1', responses.q1);
         this.set('q2', responses.q2);
         this.set('q3', responses.q3);
+        this.set('q4', responses.q4);
     }
 });

--- a/exp-player/addon/components/exp-free-response/template.hbs
+++ b/exp-player/addon/components/exp-free-response/template.hbs
@@ -1,6 +1,11 @@
 <div class="row">
-  <p class="break-line">{{t 'survey.sections.2.instructions.firstSection'}}</p>
+  <p>{{t 'survey.sections.2.instructions.firstSection'}}</p><br>
   {{#bs-form}}
+    {{#bs-form-group}}
+      <label>{{t 'survey.sections.2.questions.14.label'}}</label>
+      {{select-input options=times value=q4 translate=false}}
+    {{/bs-form-group}}
+    <p>{{t 'survey.sections.2.instructions.secondSection'}}</p>
     {{#bs-form-group}}
       <label>{{t 'survey.sections.2.questions.11.label'}}</label>
       {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=q1}}{{/textarea}}
@@ -15,10 +20,6 @@
       <label>{{t 'survey.sections.2.questions.13.label'}}</label>
       {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=q3}}{{/textarea}}
       <p class="text-muted">{{diff3}}</p>
-    {{/bs-form-group}}
-    {{#bs-form-group}}
-      <label>{{t 'survey.sections.2.questions.14.label'}}</label>
-      {{select-input options=times value=q4 translate=false}}
     {{/bs-form-group}}
   {{/bs-form}}
   <br>

--- a/exp-player/addon/components/exp-free-response/template.hbs
+++ b/exp-player/addon/components/exp-free-response/template.hbs
@@ -16,7 +16,12 @@
       {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=q3}}{{/textarea}}
       <p class="text-muted">{{diff3}}</p>
     {{/bs-form-group}}
+    {{#bs-form-group}}
+      <label>{{t 'survey.sections.2.questions.14.label'}}</label>
+      {{select-input options=times value=q4 translate=false}}
+    {{/bs-form-group}}
   {{/bs-form}}
+  <br>
 </div>
 <div class="row exp-controls">
     <button class="btn btn-default" {{ action 'previous' }}>

--- a/exp-player/addon/components/select-input/component.js
+++ b/exp-player/addon/components/select-input/component.js
@@ -5,5 +5,6 @@ import layout from './template';
 export default Ember.Component.extend({
   layout,
   options: null,
-  value: null
+  value: null,
+  translate: true
 });

--- a/exp-player/addon/components/select-input/template.hbs
+++ b/exp-player/addon/components/select-input/template.hbs
@@ -1,6 +1,12 @@
 <select class="form-control auto-width" onchange={{action (mut value) value="target.value"}}>
   <option value=null>{{t 'global.selectUnselected'}}</option>
   {{#each options as |option|}}
-    <option value={{option}} selected={{eq value option}}>{{t option}}</option>
+    <option value={{option}} selected={{eq value option}}>
+      {{#if translate}}
+        {{t option}}
+      {{else}}
+        {{option}}
+      {{/if}}
+    </option>
   {{/each}}
 </select>

--- a/exp-player/config/environment.js
+++ b/exp-player/config/environment.js
@@ -2,5 +2,9 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return { };
+  return {
+      moment: {
+          includeLocales: true
+      }
+  }
 };

--- a/exp-player/config/environment.js
+++ b/exp-player/config/environment.js
@@ -5,6 +5,29 @@ module.exports = function(/* environment, appConfig */) {
   return {
       moment: {
           includeLocales: true
+      },
+      localeTimeFormats: {
+          //TODO: Verify time formats
+          'am-ET': {
+              longDateFormat: {
+                  LT: "HH:mm"
+              }
+          },
+          'lg-UG': {
+              longDateFormat: {
+                  LT: "HH:mm"
+              }
+          },
+          'rk-UG': {
+              longDateFormat: {
+                  LT: "HH:mm"
+              }
+          },
+          'ur': {
+              longDateFormat: {
+                  LT: "HH:mm"
+              }
+          }
       }
-  }
+  };
 };


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-262

## Purpose
On the exp-free-response component, add question asking the participant what time the situation occurred.

## Summary of changes
- Ask the participant to describe a memorable situation and what time it happened: 
![screen shot 2016-10-17 at 5 48 50 pm](https://cloud.githubusercontent.com/assets/6414394/19457013/5f60ebfe-9492-11e6-9f17-b2f2f070157b.png)
- Use moment.js to localize times for the drop-down question "Approximately what time did the experience begin?" The `longDateFormat` key for unsupported locales are defined in `config/environment.js`

## Testing notes
- Select English(US) from the flag-picker modal. On the second survey page, ensure the options for the first question "Approximately what time did the experience begin?" are in 12-hr AM/PM notation. 
- Select English(GB) from the flag-picker modal. For the same question as before, ensure the times are using 24-hour notation. 
