### PR TITLE
Add labels to overview form radio questions [LEI-263]

### DIFF
--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -62,7 +62,7 @@ const questions = [
     type: 'radio',
     scale: range(1, 10),
     labelTop: false,
-    formatLabel: 'negative-margin-top',
+    formatLabel: 'negative-margin-top narrow-width',
     value: null,
     labels: [
         {
@@ -107,7 +107,7 @@ const questions = [
     scale: range(1, 11),
     hiddenOptions: [11],
     labelTop: false,
-    formatLabel: 'negative-margin-top',
+    formatLabel: 'negative-margin-top narrow-width',
     value: null,
     labels: [
         {

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -29,11 +29,6 @@ var generateValidators = function(questions) {
   return validators;
 };
 
-var getQuestion8Options = function() {
-    var scale = range(1, 10);
-    scale.push('survey.sections.1.questions.8.options.preferNoAnswer');
-    return scale;
-};
 
 const questions = [
   {
@@ -109,7 +104,8 @@ const questions = [
   {
     question: 'survey.sections.1.questions.8.label',
     type: 'radio',
-    scale: getQuestion8Options(),
+    scale: range(1, 11),
+    hiddenOptions: [11],
     labelTop: false,
     formatLabel: 'negative-margin-top',
     value: null,
@@ -121,6 +117,10 @@ const questions = [
         {
             rating: 10,
             label: 'survey.sections.1.questions.8.options.highlyReligious'
+        },
+        {
+            rating: 11,
+            label: 'survey.sections.1.questions.8.options.preferNoAnswer'
         }
     ]
   },

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -29,6 +29,12 @@ var generateValidators = function(questions) {
   return validators;
 };
 
+var getQuestion8Options = function() {
+    var scale = range(1, 10);
+    scale.push('survey.sections.1.questions.8.options.preferNoAnswer');
+    return scale;
+};
+
 const questions = [
   {
     question: 'survey.sections.1.questions.1.label',
@@ -60,8 +66,24 @@ const questions = [
     question: 'survey.sections.1.questions.5.label',
     type: 'radio',
     scale: range(1, 10),
-    labelTop: true,
-    value: null
+    labelTop: false,
+    formatLabel: 'negative-margin-top',
+    value: null,
+    labels: [
+        {
+            rating: 1,
+            label: 'survey.sections.1.questions.5.options.least'
+        },
+        {
+            rating: 5,
+            label: 'survey.sections.1.questions.5.options.average',
+            formatClass: 'format-average-label'
+        },
+        {
+            rating: 10,
+            label: 'survey.sections.1.questions.5.options.most'
+        }
+    ]
   },
   {
     question: 'survey.sections.1.questions.6.label',
@@ -87,9 +109,20 @@ const questions = [
   {
     question: 'survey.sections.1.questions.8.label',
     type: 'radio',
-    scale: range(1, 10),
-    labelTop: true,
-    value: null
+    scale: getQuestion8Options(),
+    labelTop: false,
+    formatLabel: 'negative-margin-top',
+    value: null,
+    labels: [
+        {
+            rating: 1,
+            label: 'survey.sections.1.questions.8.options.notReligious'
+        },
+        {
+            rating: 10,
+            label: 'survey.sections.1.questions.8.options.highlyReligious'
+        }
+    ]
   },
   {
     question: 'survey.sections.1.questions.9.label',

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -6,7 +6,14 @@
           {{#unless question.optional}}
             <label>{{t question.question}}</label>
             {{#if (eq question.type 'radio')}}
-              {{isp-radio-group options=question.scale labelTop=question.labelTop labels=question.labels formatLabel=question.formatLabel value=question.value}}
+              {{isp-radio-group
+                options=question.scale
+                hiddenOptions=question.hiddenOptions
+                labelTop=question.labelTop
+                labels=question.labels
+                formatLabel=question.formatLabel
+                value=question.value
+              }}
             {{else if (eq question.type 'select')}}
               {{select-input options=question.scale value=question.value}}
             {{else if (eq question.type 'input')}}

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -6,7 +6,7 @@
           {{#unless question.optional}}
             <label>{{t question.question}}</label>
             {{#if (eq question.type 'radio')}}
-              {{isp-radio-group options=question.scale labelTop=question.labelTop value=question.value}}
+              {{isp-radio-group options=question.scale labelTop=question.labelTop labels=question.labels formatLabel=question.formatLabel value=question.value}}
             {{else if (eq question.type 'select')}}
               {{select-input options=question.scale value=question.value}}
             {{else if (eq question.type 'input')}}

--- a/exp-player/addon/components/isp-radio-group/component.js
+++ b/exp-player/addon/components/isp-radio-group/component.js
@@ -6,5 +6,12 @@ export default ExpRadioGroupComponent.extend({
   layout,
   labelTop: null,
   labels: null,
-  formatLabel: null
+  formatLabel: null,
+
+  /**
+   * Option values that should not be displayed
+   * @property hiddenOptions
+   * @type: {Array}
+  */
+  hiddenOptions: []
 });

--- a/exp-player/addon/components/isp-radio-group/template.hbs
+++ b/exp-player/addon/components/isp-radio-group/template.hbs
@@ -2,7 +2,13 @@
     {{#each options as |option index|}}
       <label class="text-center label-text {{if formatLabel formatLabel}}">
           {{#if labelTop}}
-            {{t option}}
+            {{#if hiddenOptions}}
+              {{#each hiddenOptions as |hidden|}}
+                <span class="{{if (eq hidden option) 'hidden'}}">{{t option}}</span>
+              {{/each}}
+            {{else}}
+                {{t option}}
+            {{/if}}
             {{radio-button value=(last-segment option) checked=value}}
             {{#each-in labels as |ratings value|}}
               {{#if (eq value.rating option)}}
@@ -20,7 +26,13 @@
               {{/if}}
             {{/each-in}}
             {{radio-button value=(last-segment option) checked=value}}
-            {{t option}}
+            {{#if hiddenOptions}}
+              {{#each hiddenOptions as |hidden|}}
+                <span class="{{if (eq hidden option) 'hidden-label'}}">{{t option}}</span>
+              {{/each}}
+            {{else}}
+                {{t option}}
+            {{/if}}
           {{/if}}
       </label>
     {{/each}}

--- a/exp-player/addon/components/isp-radio-group/template.hbs
+++ b/exp-player/addon/components/isp-radio-group/template.hbs
@@ -6,13 +6,17 @@
             {{radio-button value=(last-segment option) checked=value}}
             {{#each-in labels as |ratings value|}}
               {{#if (eq value.rating option)}}
-                {{t value.label}}
+                <span class="{{if value.formatClass value.formatClass}}">
+                    {{t value.label}}
+                </span>
               {{/if}}
             {{/each-in}}
           {{else}}
             {{#each-in labels as |ratings value|}}
               {{#if (eq value.rating option)}}
-                {{t value.label}}
+                <span class="{{if value.formatClass value.formatClass}}">
+                    {{t value.label}}
+                </span>
               {{/if}}
             {{/each-in}}
             {{radio-button value=(last-segment option) checked=value}}

--- a/exp-player/addon/styles/addon.scss
+++ b/exp-player/addon/styles/addon.scss
@@ -11,6 +11,7 @@
 @import "components/exp-video-physics";
 @import "components/radio-group";
 @import "components/isp-radio-group";
+@import "components/exp-overview";
 @import "components/exp-card-sort";
 @import "components/exp-rating-form";
 @import "components/exp-thank-you";

--- a/exp-player/addon/styles/components/exp-overview.scss
+++ b/exp-player/addon/styles/components/exp-overview.scss
@@ -1,5 +1,5 @@
 .format-average-label {
-    margin-left: 10px;
+    margin-left: 5px;
     position: absolute;
     top:20px;
 }

--- a/exp-player/addon/styles/components/exp-overview.scss
+++ b/exp-player/addon/styles/components/exp-overview.scss
@@ -1,5 +1,5 @@
 .format-average-label {
-    margin-left: 5px;
+    margin-left: 10px;
     position: absolute;
     top:20px;
 }

--- a/exp-player/addon/styles/components/exp-overview.scss
+++ b/exp-player/addon/styles/components/exp-overview.scss
@@ -1,0 +1,5 @@
+.format-average-label {
+    margin-left: 10px;
+    position: absolute;
+    top:20px;
+}

--- a/exp-player/addon/styles/components/isp-radio-group.scss
+++ b/exp-player/addon/styles/components/isp-radio-group.scss
@@ -36,3 +36,7 @@
 .negative-margin-top {
     margin-top: -25px;
 }
+
+.hidden-label {
+    display: none;
+}

--- a/exp-player/addon/styles/components/isp-radio-group.scss
+++ b/exp-player/addon/styles/components/isp-radio-group.scss
@@ -40,3 +40,7 @@
 .hidden-label {
     display: none;
 }
+
+.narrow-width {
+    width: 5%;
+}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-263

## Purpose
- Add labels to the radio-button questions on the `exp-overview` form
- Add "I prefer not to answer" option to "On a scale from 1-10, how religious are you?"

## Changes
![screen shot 2016-10-19 at 11 12 07 am](https://cloud.githubusercontent.com/assets/6414394/19524794/eb8bf4d8-95ec-11e6-8919-f6ab2cf61d01.png)

