### PR TITLE
Update ember-simple-auth to avoid deprecation warnings

### DIFF
--- a/exp-models/addon/authenticators/jam-jwt.js
+++ b/exp-models/addon/authenticators/jam-jwt.js
@@ -30,7 +30,7 @@ export default BaseAuthenticator.extend({
                 });
             });
         }
-        return $.ajax({
+        let jqDeferred = $.ajax({
             method: 'POST',
             url: this.url,
             dataType: 'json',
@@ -42,5 +42,10 @@ export default BaseAuthenticator.extend({
                 }
             })
         }).then(res => res.data.attributes);
+
+        return new Ember.RSVP.Promise((resolve, reject) => {
+            jqDeferred.done(resolve);
+            jqDeferred.fail(reject);
+        });
     }
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-270
Companion to: https://github.com/CenterForOpenScience/isp/pull/88

## Purpose
Get rid of spammy "getOwner" deprecation warnings in the console, by upgrading to newest ember-simple-auth version.

## Summary of changes
- Make changes to authenticator so that we don't get `.then/.catch undefined` errors when using the new ember-simple-auth version.

These errors previously came from login.js in the ISP app:
`login.js:21 Uncaught TypeError: this.get(...).authenticate(...).then(...).catch is not a function(…)`

## Testing notes
- Try to login with a real account. It should work.
- Try to login with a fake account. It should not work, and the page should respond correctly. There should be no console errors or weird problems.