### PR TITLE
Add bottom margin to exit button [LEI-278]

### DIFF
--- a/exp-player/addon/components/exp-thank-you/template.hbs
+++ b/exp-player/addon/components/exp-thank-you/template.hbs
@@ -4,7 +4,7 @@
 </div>
 <div class="row">
     <div id="exitControls" class="text-center">
-        {{#link-to exitUrl class="btn btn-default btn-lg"}}
+        {{#link-to exitUrl id='exitButton' class="btn btn-default btn-lg"}}
             {{t 'thankyou.exitButton'}}
         {{/link-to}}
         <br>

--- a/exp-player/addon/styles/components/exp-thank-you.scss
+++ b/exp-player/addon/styles/components/exp-thank-you.scss
@@ -5,3 +5,7 @@
 #smilingGlobe {
     margin-top: 75px;
 }
+
+#exitButton {
+    margin-bottom: 15px;
+}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-278

## Purpose
Since the btn class no longer has a margin-bottom of 15px, the two buttons on the "thank you" page had no space between them. 

## Summary of changes
Add a bottom margin to the exit button on the "thank you" page so that there is space between that button and the "see results" button.

