### PR TITLE
Feature/fix time dropdown [LEI-262]

### DIFF
--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -80,7 +80,10 @@ export default ExpFrameBaseComponent.extend(Validations, {
     WhenResponse: null,
 
     responses: Ember.computed('WhatResponse', 'WhereResponse', 'WhoResponse', 'WhenResponse', function() {
-        var time = this.get('WhenResponse')['24h'];
+        var time = this.get('WhenResponse');
+        if (time !== null) {
+            time = time['24h'];
+        }
         return {
             WhenResponse: time,
             WhatResponse: this.get('WhatResponse'),

--- a/exp-player/addon/components/exp-free-response/template.hbs
+++ b/exp-player/addon/components/exp-free-response/template.hbs
@@ -9,6 +9,7 @@
             selected=WhenResponse
             options=times
             placeholder=placeholder
+            renderInPlace=true
             searchEnabled=false
             onchange=(action (mut WhenResponse))
             as |time|


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-262

## Purpose
- Make the power-select width smaller (currently takes up the full width of the page)
- Handle case where no time is selected (can happen if validation is turned off for testing)
