### PR TITLE
[WIP] Mark study complete sooner in Lookit exit workflow

### DIFF
--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -32,7 +32,7 @@ export default DS.Model.extend(JamModel, {
     username: Ember.computed.alias('id'),
 
     // Helper methods
-    generateProfileId: function () {
+    generateProfileId() {
         var id = makeId();
         var profileIds = this.get('profiles').map((profile) => profile.get('profileId').split('.')[0]);
         while (profileIds.indexOf(id) !== -1) {
@@ -41,14 +41,10 @@ export default DS.Model.extend(JamModel, {
         return `${this.get('id')}.${id}`;
     },
 
-    profileById: function (profileId) {
+    profileById(profileId) {
         // Scan the list of profiles and gets first one with matching ID (else undefined). Assumes profileIds are unique.
-        var profiles = this.get('profiles') || [];
-        var getProfile = function (item) {
-            return item.get('profileId') === profileId;
-        };
-
-        return profiles.filter(getProfile)[0];
+        const profiles = this.get('profiles') || [];
+        return profiles.find((item) => item.get('profileId') === profileId);
     },
     pastSessionsFor(experiment, profile, isCompleted) {
         var profileId = Ember.get(profile, 'profileId');

--- a/exp-models/addon/models/account.js
+++ b/exp-models/addon/models/account.js
@@ -43,8 +43,12 @@ export default DS.Model.extend(JamModel, {
 
     profileById(profileId) {
         // Scan the list of profiles and gets first one with matching ID (else undefined). Assumes profileIds are unique.
-        const profiles = this.get('profiles') || [];
-        return profiles.find((item) => item.get('profileId') === profileId);
+        var profiles = this.get('profiles') || [];
+        var getProfile = function (item) {
+            return item.get('profileId') === profileId;
+        };
+
+        return profiles.filter(getProfile)[0];
     },
     pastSessionsFor(experiment, profile, isCompleted) {
         var profileId = Ember.get(profile, 'profileId');

--- a/exp-player/addon/components/exp-exit-survey-pilot.js
+++ b/exp-player/addon/components/exp-exit-survey-pilot.js
@@ -86,7 +86,9 @@ export default ExpFrameBaseComponent.extend(Validations, FullScreen, {
     actions: {
         advanceToProgressBar() {
             // Move from section 1 (survey) to section 2 (progress bar/ finish button)
+             // Mark the session complete at this stage, as all data has been entered
             this.set('section1', false);
+            this.sendAction('sessionCompleted');
             this.send('save');
         },
         continue () {

--- a/exp-player/addon/components/exp-exit-survey.js
+++ b/exp-player/addon/components/exp-exit-survey.js
@@ -86,7 +86,9 @@ export default ExpFrameBaseComponent.extend(Validations, FullScreen, {
     actions: {
         advanceToProgressBar() {
             // Move from section 1 (survey) to section 2 (progress bar/ finish button)
+            // Mark the session complete at this stage, as all data has been entered
             this.set('section1', false);
+            this.sendAction('sessionCompleted');
             this.send('save');
         },
         continue () {


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-259

## Purpose
Mark study complete when user finishes exit survey, rather than when user clicks Return to Lookit at the final progress bar screen.

This is slightly more accurate and intuitive.

## Testing notes
Before the change: complete an experiment, and then complete an exit survey. No data should be saved when moving from survey to progress bar/ thank you screen.

After the change: data should be saved in that step, and `session.completed` should change from false to true.