### PR TITLE
Make consuming apps responsible for installing ember power select

### DIFF
--- a/exp-player/package.json
+++ b/exp-player/package.json
@@ -39,6 +39,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-i18n": "4.2.2",
+    "ember-power-select": "1.0.0-beta.25",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.5.1",
     "ember-sinon-qunit": "1.3.4",
@@ -57,8 +58,7 @@
     "broccoli-merge-trees": "^1.1.1",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "0.7.4",
-    "ember-cp-validations": "2.9.2",
-    "ember-power-select": "1.0.0-beta.25"
+    "ember-cp-validations": "2.9.2"
   },
   "eslintConfig": {
     "ecmaFeatures": {


### PR DESCRIPTION
Blocker for: https://openscience.atlassian.net/browse/LEI-266
Companion to: https://github.com/CenterForOpenScience/lookit/pull/68/files

## Purpose
Fix regeneratorRuntime errors in Lookit.

Installing ember-power-select as a dependency added a (nonworking) version to every app that consumed exp-player.  Instead, this change makes the consuming app responsible for installing power-select directly (if it needs it), or not installing it, as appropriate.

## Summary of changes
- Move power select from dependencies to dev-dependencies. Light testing on ISP and Lookit.

## Testing notes
- We will need to add ember-power-select as a dependency to experimenter.

- Checklist: both Lookit and ISP applications should build when restarting server/ after running npm install, the dropdown should work, and no regeneratorRuntime errors in console.
