### PR TITLE
Add preferNoAnswer option to religion yes/no question [LEI-286]

### DIFF
--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -139,8 +139,9 @@ const questions = [
     keyName: 'ReligionYesNo',
     type: 'radio',
     scale: [
-        {label: 'global.yesLabel', value: 1},
-        {label: 'global.noLabel', value: 2}
+        {label: 'survey.sections.1.questions.9.options.yesLabel', value: 1},
+        {label: 'survey.sections.1.questions.9.options.noLabel', value: 2},
+        {label: 'survey.sections.1.questions.9.options.preferNoAnswer', value: 3}
     ],
     labelTop: true,
     value: null


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-286

## Purpose
Add the option "I prefer not to answer" to the question "Do you follow a religion?" on the overview form: 
![screen shot 2016-10-27 at 4 51 58 pm](https://cloud.githubusercontent.com/assets/6414394/19785837/15db7c4a-9c69-11e6-8e99-0cb524fbca8c.png)


