### PR TITLE
Fix CSS for long translations [LEI-282]

### DIFF
--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -19,10 +19,17 @@
   </div>
   <h4 class="center">{{cards.length}} {{t 'qsort.sections.1.itemsLeft'}}</h4>
 {{/if}}
+<div class="row hidden-xs">
+  {{#each buckets as |bucket|}}
+    <div class="col-sm-4">
+      <h3 class="bucket-label" style={{height}}>{{t bucket.name}}</h3>
+    </div>
+  {{/each}}
+</div>
 <div class="row">
     {{#each buckets as |bucket|}}
       <div class="col-sm-4">
-          <h3 class="text-center">{{t bucket.name}}</h3>
+          <h3 class="bucket-label visible-xs" style={{height}}>{{t bucket.name}}</h3>
           {{#if (eq framePage 0)}}
             {{#draggable-object-target bucket=bucket.cards cards=cards buckets=buckets action='dragCard'}}
               <div class="well bucket">
@@ -52,7 +59,20 @@
         <div class="row">
           {{#each group.categories as |category|}}
             <div class="col-sm-4 small-bucket">
-              <h5 class="text-center {{if (eq category.name 'qsort.sections.2.categories.neutral') '' 'bucket-label'}}">{{t category.name}}</h5>
+              <h5 class="bucket-label hidden-xs {{if (eq category.name 'qsort.sections.2.categories.neutral') '' 'bucket-label-margin'}}">{{t category.name}}</h5>
+            </div>
+          {{/each}}
+        </div>
+      </div>
+    {{/each}}
+  </div>
+  <div class="row">
+    {{#each buckets2 as |group|}}
+      <div class="col-sm-4">
+        <div class="row">
+          {{#each group.categories as |category|}}
+            <div class="col-sm-4 small-bucket">
+              <h5 class="bucket-label visible-xs {{if (eq category.name 'qsort.sections.2.categories.neutral') '' 'bucket-label-margin'}}">{{t category.name}}</h5>
               <h5 class="text-center
                 {{if (gte category.cards.length category.max) (if (eq category.cards.length category.max) 'text-success' 'text-danger') ''}}">
                 {{category.cards.length}}/{{category.max}}

--- a/exp-player/addon/styles/components/exp-card-sort.scss
+++ b/exp-player/addon/styles/components/exp-card-sort.scss
@@ -30,6 +30,11 @@
     margin-bottom: 12px;
 }
 
-.bucket-label {
+.bucket-label-margin {
     margin-top: 40px;
+}
+
+.bucket-label {
+    text-align: center;
+    overflow-wrap: break-word;
 }

--- a/exp-player/addon/styles/components/isp-radio-group.scss
+++ b/exp-player/addon/styles/components/isp-radio-group.scss
@@ -17,6 +17,7 @@
   white-space: pre-line;
   overflow-wrap: break-word;
   margin-right: 10px;
+  max-width: 10%;
 }
 
 .format-label {


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-282
## Purpose

Check the formatting of labels, questions, etc. using a pseudo-translation (double each translation string) to identify places where the UI may look off with long translation strings.
## Summary of changes
- Wrap bucket labels that are too long so that they do not overlap another label
- Put bucket labels into a separate row so that the buckets can stay aligned even
  when the labels are of differing lengths
- Hide the label row on xs screens, because the row will collapse and list all of the labels and
  then all of the buckets.
- Show the bucket labels inside the bucket row on xs screens so that the labels appear directly   above the bucket.
- Set a max-width for isp-radio-component buttons so that the text wraps onto multiple lines instead of increasing the width of the label element
