### PR TITLE
Fix schema errors when saving experiments

### DIFF
--- a/exp-player/addon/components/exp-video-physics.js
+++ b/exp-player/addon/components/exp-video-physics.js
@@ -118,7 +118,7 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
                     type: 'string'
                 }
             },
-            required: []
+            // No fields are required
         }
     },
 

--- a/exp-player/addon/components/exp-video-preview.js
+++ b/exp-player/addon/components/exp-video-preview.js
@@ -158,7 +158,7 @@ export default ExpFrameBaseComponent.extend(MediaReload, VideoRecord, {
                     type: 'string'
                 }
             },
-            required: []
+            // No fields are required
         }
     },
 


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-300

## Purpose
With schema validation now turned on correctly, JamDB was rejecting frames defined with `required: []`, causing things to fail saving that previously worked. This is a syntax issue that always existed but was exposed by another recent bugfix.

If a frame specifies the required attribute, it must be an array with at least one element:
http://json-schema.org/latest/json-schema-validation.html#anchor61

When no fields are required, we will omit it for now, pending a larger rewrite of the "automatic schema generation" feature down the line.

## Summary of changes
- Removed the "required" attribute from frames with no requirements.

## Testing notes
Try saving an experiment such as:
http://localhost:4201/experiments/58178a2b3de08a007fc5989c/edit

Before the change it failed with schema errors. After, it works.

This validator was also helpful (set it to "schema draft v4"):
http://www.jsonschemavalidator.net/