### PR TITLE
Fix eventTime question deserialization [LEI-301]

### DIFF
--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -140,7 +140,14 @@ export default ExpFrameBaseComponent.extend(Validations, {
     },
     loadData: function(frameData) {
         var responses = frameData.responses;
-        this.set('EventTime', responses.EventTime);
+        var times = this.get('times');
+        var eventTime = null;
+        for (var i=0; i < times.length; i++) {
+            if (times[i]['24h'] === responses.EventTime) {
+                eventTime = times[i];
+            }
+        }
+        this.set('EventTime', eventTime);
         this.set('WhatResponse', responses.WhatResponse);
         this.set('WhereResponse', responses.WhereResponse);
         this.set('WhoResponse', responses.WhoResponse);


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-301

## Purpose
The first question on the exp-free-response frame was not getting deserialized correctly (the stored value is the 24hr time, but the options are objects containing keys for the time in 12hr and 24hr notation.

## Summary of changes
In `loadData`, check which option in `times` corresponds to the saved `24hr` time and set `EventTime` to that option.

## Testing notes
Answer the first question on the exp-free-response frame about what time the situation occurred. Click "Continue" to advance to the next frame, then click "Previous Page" to return to the free-response page. Check to see that the answer to the first question is still selected.

