### PR TITLE
Clear unsaved cardsort1 data [LEI-302]

### DIFF
--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -239,6 +239,13 @@ export default ExpFrameBaseComponent.extend({
                 window.scrollTo(0, 0);
             }
         },
+        previousPage() {
+            // clear unsaved data
+            for (let bucket of this.get('buckets')) {
+                Ember.set(bucket, 'cards', []);
+            }
+            this.send('previous');
+        },
         continue() {
             if (this.get('isValid')) {
                 this.send('next');

--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -98,7 +98,7 @@
 </div>
 <div class="row exp-controls">
     {{#if (eq framePage 0)}}
-      <div class="btn btn-default" {{ action 'previous' }}>
+      <div class="btn btn-default" {{ action 'previousPage' }}>
         {{t 'global.previousLabel'}}
       </div>
       <div class="btn btn-primary pull-right {{if allowNext '' 'disabled'}}" {{action "nextPage"}}>{{t 'global.continueLabel'}}</div>


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-302

## Purpose
If a user sorts cards on the cardsort1 page, then clicks the "Previous Page" button to
go to the previous page, and then clicks the "Continue" button to go back to the cardsort1 page, they should see 90 cards at the top to be sorted and three empty buckets to sort them into. Instead, the buckets still contain the previously sorted cards. 

## Summary of changes
When a user clicks the "Previous Page" button on the cardsort1 page, clear the sorted cards.

## Testing notes
Steps to reproduce: 
1. On the first cardsort page, sort at least one card. Notice the number of cards left decreases. 
2. Click the "Previous Page" button
3. Click the "Continue" button to return to the cardsort page
4. Notice that the number of cards left is 90, but the sorted cards still re-appear.