### PR TITLE
Feature/fix select default

### DIFF
--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -15,6 +15,7 @@ function getLength(value) {
 
 var presence = validator('presence', {
     presence: true,
+    ignoreBlank: true,
     message: 'This field is required'
 });
 

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -17,6 +17,7 @@ var generateValidators = function(questions) {
   var validators = {};
   var presence = validator('presence', {
     presence:true,
+    ignoreBlank: true,
     message: 'This field is required'
   });
   for (var q=0; q < questions.length; q++) {

--- a/exp-player/addon/components/select-input/template.hbs
+++ b/exp-player/addon/components/select-input/template.hbs
@@ -1,5 +1,5 @@
 <select class="form-control auto-width" onchange={{action (mut value) value="target.value"}}>
-  <option value=null>{{t 'global.selectUnselected'}}</option>
+  <option value="">{{t 'global.selectUnselected'}}</option>
   {{#each options as |option|}}
     <option value={{option.value}} selected={{eq value option.value}}>{{t option.label}}</option>
   {{/each}}


### PR DESCRIPTION
Refs: https://trello.com/c/cwBpdYLi/5-edge-case-overview-background-form-if-user-fills-out-form-but-then-changes-age-gender-residence-to-default-please-select-they-ar

## Purpose
If a user fills out the overview form, and then changes the answer to a select-type question back to the default option "Please select", they are still able to submit the form even though that question is required.

Similarly, if a user fills out the form and answers an input-type question with only whitespace, it is considered valid. 

## Summary of changes
- Change the default value of the select-input component to `""` instead of `"null"` so that it does not pass validation.
- Pass the `ignoreBlank` option into the presence validator on pages with required input-type questions (currently just the overview and free-response forms) so that all-whitespace answers are not allowed. 
