### PR TITLE
Feature: fix select validation [LEI-306]

### DIFF
--- a/exp-player/addon/components/exp-frame-base.js
+++ b/exp-player/addon/components/exp-frame-base.js
@@ -69,7 +69,7 @@ export default Ember.Component.extend({
             this.set('id', `${kind}-${frameIndex}`);
         }
 
-        if (config.featureFlags.loadData) {
+        if (clean && config.featureFlags.loadData) {
             var session = this.get('session');
             var expData = session ? session.get('expData') : null;
             if (session && session.get('expData')) {

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -254,7 +254,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
         for (var q=0; q < this.get('questions').length; q++) {
             var question = this.get('questions')[q];
             var keyName = question.keyName;
-            this.get('questions')[q].value = frameData.responses[keyName];
+            Ember.set(question, 'value', frameData.responses[keyName]);
         }
     }
 });

--- a/exp-player/addon/components/select-input/template.hbs
+++ b/exp-player/addon/components/select-input/template.hbs
@@ -1,5 +1,5 @@
 <select class="form-control auto-width" onchange={{action (mut value) value="target.value"}}>
-  <option value="">{{t 'global.selectUnselected'}}</option>
+  <option value="" selected="">{{t 'global.selectUnselected'}}</option>
   {{#each options as |option|}}
     <option value={{option.value}} selected={{eq value option.value}}>{{t option.label}}</option>
   {{/each}}


### PR DESCRIPTION
Refs: 
- https://trello.com/c/cwBpdYLi/5-edge-case-overview-background-form-if-user-fills-out-form-but-then-changes-age-gender-residence-to-default-please-select-they-ar
- https://openscience.atlassian.net/browse/LEI-306

## Purpose
- Fix `Assertion Failed: You must use Ember.set() to set the value property` that prevents users from advancing to free-response form after clicking "Continue" on the overview form. 
- Fix issue where `loadData` gets called after changing the value of a question, overwriting the new value (e.g. when clicking "Previous Page" to return to the overview form from the free-response form, changing a select question back to "Please Select" would not make the "Continue" button disabled because the value was getting overwritten with the previous, valid value)

## Summary of changes
- Use `Ember.set()` to set question values 
- Only call `loadData` from `didReceiveAttrs` if the frameIndex has changed

## Testing notes
1. Fill out the overview form and click "Continue"
2. On the next frame (exp-free-response), click "Previous Page" to return to the overview form
3. Change the answer to the first question to "Please Select". The continue button should be disabled.
4. Change the answer back to a valid answer. The continue button should be enabled.
5. After clicking the continue button, you should be taken to the free-response page.
