### PR TITLE
Fix card text overflowing card

### DIFF
--- a/exp-player/addon/styles/components/exp-card-sort.scss
+++ b/exp-player/addon/styles/components/exp-card-sort.scss
@@ -34,6 +34,7 @@
     padding: 10px;
     margin-bottom: 12px;
     overflow-wrap: break-word;
+    word-wrap: break-word; // support for original name: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap
 }
 
 .bucket-label-margin {

--- a/exp-player/addon/styles/components/exp-card-sort.scss
+++ b/exp-player/addon/styles/components/exp-card-sort.scss
@@ -21,13 +21,19 @@
     font-size: 10px;
 }
 
+.small-bucket {
+    padding-right: 8px;
+    padding-left: 8px;
+}
+
 .small-bucket .well {
-    padding:12px;
+    padding:10px;
 }
 
 .small-bucket .alert {
     padding: 10px;
     margin-bottom: 12px;
+    overflow-wrap: break-word;
 }
 
 .bucket-label-margin {


### PR DESCRIPTION
Refs: https://trello.com/c/e5LbqRT8/4-text-on-cards-in-sub-categories-runs-off-card

## Purpose
On small screen widths, card text runs off of cards.

## Summary of changes
- Make buckets wider
- Make cards wider
- Make card text break in between long words 

![screen shot 2016-11-06 at 6 44 08 pm](https://cloud.githubusercontent.com/assets/6414394/20042981/faeb6648-a451-11e6-90b7-bb928937c45b.png)  

![screen shot 2016-11-06 at 6 44 20 pm](https://cloud.githubusercontent.com/assets/6414394/20042983/fe377c9c-a451-11e6-88c4-d9d7c8ebfd63.png)



