### PR TITLE
[rfr] Create batch contributors as a bulk operation

### DIFF
--- a/exp-models/addon/mixins/bulk-adapter.js
+++ b/exp-models/addon/mixins/bulk-adapter.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+/**
+ * @module exp-models
+ * @submodule mixins
+ */
+
+/**
+ * Add support for bulk operations, as defined by the (deprecated) JSONAPI Bulk Operations extension proposal
+ *   https://github.com/json-api/json-api/blob/9c7a03dbc37f80f6ca81b16d444c960e96dd7a57/extensions/bulk/index.md
+ *   https://github.com/CenterForOpenScience/jamdb/blob/master/features/document/create.feature#L167
+ *
+ * @class BulkAdapterMixin
+ */
+export default Ember.Mixin.create({
+    ajaxOptions(_, __, options) {
+        const ret = this._super(...arguments);
+        if (options && options.isBulk) {
+            ret.contentType = 'application/vnd.api+json; ext=bulk';
+        }
+        return ret;
+    }
+});

--- a/exp-models/addon/mixins/jam-document-adapter.js
+++ b/exp-models/addon/mixins/jam-document-adapter.js
@@ -1,6 +1,20 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
+import BulkAdapterMixin from './bulk-adapter';
+
+/**
+ * @module exp-models
+ * @submodule adapters
+ */
+
+/**
+ * Adapter for communication with a remote JamDB server
+ *
+ * @class JamDocumentAdapterMixin
+ * @uses BulkAdapterMixin
+ */
+
+export default Ember.Mixin.create(BulkAdapterMixin, {
     updateRecordUrlTemplate: '{+host}/{+namespace}/documents{/namespaceId}.{collectionId}.{id}',
     findRecordUrlTemplate: '{+host}/{+namespace}/documents{/namespaceId}.{collectionId}.{id}',
 


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-305
Companion to: https://github.com/CenterForOpenScience/experimenter/pull/120

## Purpose
Experimenter should allow batch creation of records. This adds custom headers to requests where appropriate.

## Summary of changes

### TODO
- [x] Add adapter support for bulk operations (headers)
- [x] Add form validation to the participant creation UI so that users can't create more than 100 records at a time (max bulk size)
- [x] Add participant creation helper methods to create the desired records in bulk
- [x] Refactor the allSettled promises in participant-creator (TODO: Reformat when the code isn't being actively changed)
- [x] Add error handling around creation

## Testing notes
To be written