### PR TITLE
Fix collection bug that breaks ability to log in via Jam auth

### DIFF
--- a/exp-models/addon/models/collection.js
+++ b/exp-models/addon/models/collection.js
@@ -2,16 +2,18 @@
  Manage data about a given collection
  */
 
+import Ember from 'ember';
 import DS from 'ember-data';
 import JamModel from '../mixins/jam-model';
 
 export default DS.Model.extend(JamModel, {
-    name: function () {
+    name: Ember.computed('id', function () {
         return this.get('id').split('.')[1];
-    }.property(),
+    }),
 
     schema: DS.attr(),
     permissions: DS.attr(),
+    plugins: DS.attr(),
 
     namespace: DS.belongsTo('namespace')
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-313
Companion to: https://github.com/CenterForOpenScience/experimenter/pull/126

## Purpose
Fix an issue where saving collections permissions via ember broke the ability to log in.

(Ember was dropping the undocumented `plugins` field required for the accounts collection to work, as discovered in companion PR testing)

## Summary of changes
Add a plugins field to the collection serializer

## Testing notes
See companion ticket.

For now we only need to save the `accounts` collection in ember- PATCH requests to the server for this endpoint are a limited use case. We may dig farther in the future as we add special permissions for other collections.