### PR TITLE
"Query everything" helper for store

### DIFF
--- a/exp-models/addon/services/store.js
+++ b/exp-models/addon/services/store.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+
+import DS from 'ember-data';
+
+export default DS.Store.extend({
+
+    _queryEverythingHelper(collectionName, dest, params, options, page=1) {
+        // User-specified parameters override any other configuration passed in. For now, assume that all options are
+        //   treated as query params; may not always be true.
+        let queryParams = Object.assign({}, options, {page}, params);
+
+        return this.query(collectionName, queryParams).then(res => {
+            const theseResults = res.toArray();
+            dest.push(...theseResults);
+            // TODO: This is an imperfect means of identifying the last page, but JamDB doesn't tell us directly
+            if (theseResults.length !== 0 && dest.length < res.get('meta.total')) {
+                return this._queryEverythingHelper(collectionName, dest, params, options, page + 1);
+            } else {
+                return dest;
+            }
+        });
+    },
+
+    /**
+     * Depaginate the API by performing a query that fetches all records
+     * @method queryEverything
+     *
+     * @param {String} collectionName Name of the collection to query
+     * @param {Object} params An object containing user-provided query parameters
+     * @param {Object} options Recognized configuration options that control behavior, including `page` (start page) and `page[size]` (# results/page).
+     *   For now options are all used as query params, but that may change.
+     * @returns {Promise} A (chained) promise that will resolve to dest when all records have been fetched
+     * @private
+     */
+    queryEverything(collectionName, params, options={}) {
+        const results = Ember.A();
+        options = Object.assign({}, {'page[size]': 100}, options);
+        return this._queryEverythingHelper(collectionName, results, params, options);
+    }
+
+});

--- a/exp-models/addon/services/store.js
+++ b/exp-models/addon/services/store.js
@@ -29,8 +29,7 @@ export default DS.Store.extend({
      * @param {Object} params An object containing user-provided query parameters
      * @param {Object} options Recognized configuration options that control behavior, including `page` (start page) and `page[size]` (# results/page).
      *   For now options are all used as query params, but that may change.
-     * @returns {Promise} A (chained) promise that will resolve to dest when all records have been fetched
-     * @private
+     * @returns {Promise} A (chained) promise that will resolve to an array when all records have been fetched
      */
     queryEverything(collectionName, params, options={}) {
         const results = Ember.A();

--- a/exp-models/app/services/store.js
+++ b/exp-models/app/services/store.js
@@ -1,0 +1,1 @@
+export { default } from 'exp-models/services/store';


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-313
Companion to: 

## Purpose
Provide a helper method to depaginate the API.

We don't want to use this very often, but there are some specific use cases- particularly centered around exporting results for site administrators.

- Experimenter "all data" page
- Lookit "all sessions" (questionable; we should just redesign the page)
- ISP "who completed my study"

## Summary of changes
- Extend the store with a custom helper method. Limited initial support for options to control the request (eg what page to start from)- the ability to configure this has not been extensively tested.

## Testing notes
- See usage example in companion PR.
