### PR TITLE
Add missing fields to exp-rating-form [LEI-332]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "4.6.0"
+  - "lts/boron"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  - npm install npm@latest -g
   - npm config set spin false
   - npm install -g bower
 

--- a/exp-models/package.json
+++ b/exp-models/package.json
@@ -30,7 +30,6 @@
     "ember-cli-qunit": "^2.1.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-template-lint": "0.5.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.8.0",

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -173,8 +173,7 @@ var items = {
         'measures.questions.16.items.2.label',
         'measures.questions.16.items.3.label',
         'measures.questions.16.items.4.label',
-        'measures.questions.16.items.5.label',
-        'measures.questions.16.items.6.label'
+        'measures.questions.16.items.5.label'
     ],
     '17': [
         'measures.questions.17.items.1.label',

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -145,7 +145,8 @@ var items = {
         'measures.questions.13.items.1.label',
         'measures.questions.13.items.2.label',
         'measures.questions.13.items.3.label',
-        'measures.questions.13.items.4.label'
+        'measures.questions.13.items.4.label',
+        'measures.questions.13.items.5.label'
     ],
     '14': [
         'measures.questions.14.items.1.label',
@@ -172,7 +173,8 @@ var items = {
         'measures.questions.16.items.2.label',
         'measures.questions.16.items.3.label',
         'measures.questions.16.items.4.label',
-        'measures.questions.16.items.5.label'
+        'measures.questions.16.items.5.label',
+        'measures.questions.16.items.6.label'
     ],
     '17': [
         'measures.questions.17.items.1.label',

--- a/exp-player/package.json
+++ b/exp-player/package.json
@@ -34,7 +34,6 @@
     "ember-cli-release": "^0.2.9",
     "ember-cli-showdown": "2.5.0",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-template-lint": "0.5.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.8.0",


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-332
Companion to: N/A fix

## Purpose
Question was missing from item 13 in exp-rating-form

## Summary of changes
1-liner addition to exp-rating-form

## Testing notes
There should be 5 questions under "11. Please rate the extent to which you agree or disagree with the following statements:"
The last of which should be "Most people are trustworthy."

![screen shot 2016-12-14 at 11 54 07](https://cloud.githubusercontent.com/assets/3374510/21191705/0dbd794a-c1f4-11e6-9c04-a7d54d825bb8.png)


