### PR TITLE
Update csv-writer to use a blank value for JSON null type

### DIFF
--- a/exp-models/addon/utils/csv-writer.js
+++ b/exp-models/addon/utils/csv-writer.js
@@ -82,7 +82,7 @@ function csvSafe(val) {
             return value.toString();
         case 'object':
             if (value === null) {
-                return 'null';
+                return '';
             }
 
             value = JSON.stringify(value);

--- a/exp-models/tests/unit/utils/csv-writer-test.js
+++ b/exp-models/tests/unit/utils/csv-writer-test.js
@@ -344,7 +344,7 @@ test('Multiple types of data', function(assert) {
         result,
         [
             'alpha,bravo,charlie,delta,echo,foxtrot,golf,hotel,juliet,lima,kilo',
-            '1,null,"str",,,,,,,,',
+            '1,,"str",,,,,,,,',
             ',,,"{""obj"":""val""}","[""a"",""b"",""c""]",TRUE,FALSE,,,,',
             ',,,,,,,,Infinity,-Infinity,NaN'
         ].join(NL)


### PR DESCRIPTION
Companion to: CenterForOpenScience/experimenter#129

## Purpose
Changes csv-writer util to output an empty string `''` instead of `'null'`

## Summary of changes
csv-writer and test

## Testing notes
JSON null should be an empty string

