### PR TITLE
Production site should build in production mode

### DIFF
--- a/exp-models/addon/models/experiment.js
+++ b/exp-models/addon/models/experiment.js
@@ -13,13 +13,8 @@ import SessionAdapter from '../adapters/session';
 import SessionModel from '../models/session';
 import SessionSerializer from '../serializers/session';
 
-export default DS.Model.extend(JamModel, {
+const Experiment = DS.Model.extend(JamModel, {
     namespaceConfig: Ember.inject.service(),
-
-    ACTIVE: 'Active',
-    DRAFT: 'Draft',
-    ARCHIVED: 'Archived',
-    DELETED: 'Deleted',
 
     title: DS.attr('string'),
     description: DS.attr('string'),
@@ -209,3 +204,12 @@ export default DS.Model.extend(JamModel, {
 
     // TODO: In the future, we would like to automatically set session access appropriately when the value of isActive changed AND the experiment record is saved to the server (observer easy for one event, less so for the combination)
 });
+
+Experiment.reopenClass({
+    ACTIVE: 'Active',
+    DRAFT: 'Draft',
+    ARCHIVED: 'Archived',
+    DELETED: 'Deleted',
+});
+
+export default Experiment;

--- a/exp-models/addon/models/experiment.js
+++ b/exp-models/addon/models/experiment.js
@@ -13,6 +13,15 @@ import SessionAdapter from '../adapters/session';
 import SessionModel from '../models/session';
 import SessionSerializer from '../serializers/session';
 
+// Known states available to experiments. Available as instance variables, or may be imported and used as an enum
+//   directly when no instance is available.
+const expStates = {
+    ACTIVE: 'Active',
+    DRAFT: 'Draft',
+    ARCHIVED: 'Archived',
+    DELETED: 'Deleted',
+};
+
 const Experiment = DS.Model.extend(JamModel, {
     namespaceConfig: Ember.inject.service(),
 
@@ -205,11 +214,8 @@ const Experiment = DS.Model.extend(JamModel, {
     // TODO: In the future, we would like to automatically set session access appropriately when the value of isActive changed AND the experiment record is saved to the server (observer easy for one event, less so for the combination)
 });
 
-Experiment.reopenClass({
-    ACTIVE: 'Active',
-    DRAFT: 'Draft',
-    ARCHIVED: 'Archived',
-    DELETED: 'Deleted',
-});
+// Add states enum as instance-level variables for convenience / backwards compatibility
+Experiment.reopen(expStates);
 
 export default Experiment;
+export {expStates};


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-275
Companion to: TBD

## Purpose
Address error where attributes were not available on prototype in Lookit production builds (though they were available in debug mode builds)

This removes blockers for Lookit, Experimenter, and ISP apps to deploy in production mode.

## Summary of changes
- Make `expStates` available as an enum when no instance is available (useful for Lookit queries)

## Testing notes
Primary testing for this PR will be done as used with LEI consuming apps.