### PR TITLE
Fix average label positioning

### DIFF
--- a/exp-player/addon/styles/components/exp-overview.scss
+++ b/exp-player/addon/styles/components/exp-overview.scss
@@ -1,5 +1,6 @@
 .format-average-label {
-    margin-left: 10px;
-    position: absolute;
+    display: block;
+    width: 100%;
+    margin-left: calc(50% + 10px);
     top:20px;
 }


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-296
Companion to: will update ISP submodule reference after merge

## Purpose
Fixes "Average" label positioning for question 5

### Before:
![screen shot 2016-12-21 at 15 03 14](https://cloud.githubusercontent.com/assets/3374510/21404360/cb986aca-c78e-11e6-88eb-4208d94e9d0a.png)
![screen shot 2016-12-21 at 15 03 23](https://cloud.githubusercontent.com/assets/3374510/21404370/dc122f94-c78e-11e6-8e30-f791206927fb.png)

### After:
![screen shot 2016-12-21 at 14 58 11](https://cloud.githubusercontent.com/assets/3374510/21404268/688f3940-c78e-11e6-8e8d-274523a4f0a8.png)
![screen shot 2016-12-21 at 14 58 35](https://cloud.githubusercontent.com/assets/3374510/21404273/6db3b68a-c78e-11e6-8164-d99ef7808e0d.png)

#### x-pseudo
![screen shot 2016-12-21 at 15 24 17](https://cloud.githubusercontent.com/assets/3374510/21405023/1a03b6bc-c792-11e6-9cea-57f0355ad700.png)
![screen shot 2016-12-21 at 15 24 36](https://cloud.githubusercontent.com/assets/3374510/21405025/1db4f820-c792-11e6-9e0f-8bbd1270d00f.png)

#### German
![screen shot 2016-12-21 at 15 25 52](https://cloud.githubusercontent.com/assets/3374510/21405031/26d5f7ec-c792-11e6-810a-8653cc8a81e4.png)
![screen shot 2016-12-21 at 15 26 03](https://cloud.githubusercontent.com/assets/3374510/21405037/2d0c5750-c792-11e6-9226-2af5895f92d8.png)

#### Indonesian
![screen shot 2016-12-21 at 15 26 45](https://cloud.githubusercontent.com/assets/3374510/21405052/40eeaba6-c792-11e6-906a-cc41455fc832.png)
![screen shot 2016-12-21 at 15 26 58](https://cloud.githubusercontent.com/assets/3374510/21405059/4b1b6d94-c792-11e6-9803-c211024dd95c.png)


## Summary of changes
CSS only fix for the exp-overview scss file

## Testing notes
The average label on should be positioned between 5 and 6 above the radio buttons
