### PR TITLE
Invalidate session on 403 error

### DIFF
--- a/exp-models/addon/mixins/jam-document-adapter.js
+++ b/exp-models/addon/mixins/jam-document-adapter.js
@@ -37,7 +37,7 @@ export default Ember.Mixin.create(BulkAdapterMixin, {
     },
 
     handleResponse(status) {
-        // Data adapter mixin only handles 401; Jam sometimes returns 403 instead
+        // Data adapter mixin only handles 401; Jam sometimes returns 403 instead. Make sure that triggers invalidation.
         if (status === 403 && this.get('session.isAuthenticated')) {
             this.get('session').invalidate();
         }

--- a/exp-models/addon/mixins/jam-document-adapter.js
+++ b/exp-models/addon/mixins/jam-document-adapter.js
@@ -34,5 +34,13 @@ export default Ember.Mixin.create(BulkAdapterMixin, {
     ajax: function(url, type, options={}) {
         options.traditional = true;
         return this._super(...arguments);
+    },
+
+    handleResponse(status) {
+        // Data adapter mixin only handles 401; Jam sometimes returns 403 instead
+        if (status === 403 && this.get('session.isAuthenticated')) {
+            this.get('session').invalidate();
+        }
+        return this._super(...arguments);
     }
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-345
Companion to: https://github.com/CenterForOpenScience/isp/pull/123

## Purpose
When Jam fails due to invalid or expired tokens, in some cases it returns a 403. At present, we don't have a "repair" mechanism if a user gets logged out mid-study; thus the appropriate response to a 401 or 403 is to invalidate the session. Consuming apps can then decide how to handle that invalidation- usually by kicking the user back to the login page and wiping any state from memory. (hard reload)

See: https://github.com/simplabs/ember-simple-auth/blob/master/addon/mixins/data-adapter-mixin.js#L122

## Summary of changes
See above

## Testing notes
See companion PR
