### PR TITLE
When using rtl language, display radio buttons in different order

### DIFF
--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -125,6 +125,10 @@ export default ExpFrameBaseComponent.extend({
     type: 'exp-card-sort',
     layout: layout,
     framePage: 0,
+
+    extra: {},
+    isRTL: Ember.computed.alias('extra.isRTL'),
+
     pageNumber: Ember.computed('framePage', function() {
         return this.get('framePage') + 3;
     }),

--- a/exp-player/addon/components/exp-frame-base/component.js
+++ b/exp-player/addon/components/exp-frame-base/component.js
@@ -13,6 +13,8 @@ export default Ember.Component.extend({
     id: null,
     kind: null,
 
+    extra: {},
+
     meta: { // Configuration for all fields available on the component/template
         name: 'Base Experimenter Frame',
         description: 'The abstract base frame for Experimenter frames.',

--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -32,6 +32,10 @@ export default ExpFrameBaseComponent.extend(Validations, {
     layout: layout,
     i18n: Ember.inject.service(),
     pageNumber: 2,
+
+    extra: {},
+    isRTL: Ember.computed.alias('extra.isRTL'),
+
     diff1: Ember.computed('WhatResponse', function () {
         var length = getLength(this.get('WhatResponse'));
         var message = this.get('i18n').t('survey.sections.2.questions.11.characterCount').string;

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -163,6 +163,9 @@ export default ExpFrameBaseComponent.extend(Validations, {
     questions: questions,
     pageNumber: 1,
 
+    extra: {},
+    isRTL: Ember.computed.alias('extra.isRTL'),
+
     showOptional: Ember.computed('questions.9.value', function () {
         return this.questions[9].value === 1;
     }),

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -14,7 +14,6 @@
                             labels=question.labels
                             formatLabel=question.formatLabel
                             value=question.value
-
                             isRTL=isRTL
                         }}
                     {{else if (eq question.type 'select')}}

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -14,6 +14,8 @@
                             labels=question.labels
                             formatLabel=question.formatLabel
                             value=question.value
+
+                            isRTL=isRTL
                         }}
                     {{else if (eq question.type 'select')}}
                         {{select-input options=question.scale value=question.value}}

--- a/exp-player/addon/components/exp-player/component.js
+++ b/exp-player/addon/components/exp-player/component.js
@@ -46,6 +46,10 @@ export default Ember.Component.extend(FullScreen, {
     allowExit: false,
     hasAttemptedExit: false,
 
+    // Any additional properties we might wish to pass from the player to individual frames. Allows passing of arbitrary config
+    // by individual consuming applications to suit custom needs.
+    extra: {},
+
     /**
      * The message to display in the early exit modal. Newer browsers may not respect this message.
      * @property {String|null} messageEarlyExitModal

--- a/exp-player/addon/components/exp-player/template.hbs
+++ b/exp-player/addon/components/exp-player/template.hbs
@@ -25,6 +25,8 @@
                   saveHandler=(action 'saveFrame')
                   skipone=(action 'skipone')
                   sessionCompleted=(action 'sessionCompleted')
+
+                  extra=extra
         }}
     </div>
 </div>

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -649,6 +649,10 @@ export default ExpFrameBaseComponent.extend(Validations, {
     layout: layout,
     framePage: 0,
     lastPage: 6,
+
+    extra: {},
+    isRTL: Ember.computed.alias('extra.isRTL'),
+
     progressBarPage: Ember.computed('framePage', function () {
         return this.framePage + 5;
     }),

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -11,7 +11,8 @@
                                 <label>{{t item.description}}</label>
                             {{/if}}
                             {{isp-radio-group options=question.scale labelTop=item.labelTop labels=item.labels
-                                              formatLabel=item.formatLabel value=item.value}}
+                                              formatLabel=item.formatLabel value=item.value isRTL=isRTL
+                            }}
                             <br>
                             <br>
                         {{/each}}
@@ -19,13 +20,13 @@
                         {{select-input options=question.scale value=question.items.0.value}}
                     {{else if (eq question.type 'radio-input')}}
                         {{isp-radio-group options=question.scale formatLabel=question.items.0.formatLabel
-                                          value=question.items.0.value}}
+                                          value=question.items.0.value isRTL=isRTL}}
                         {{#if (eq question.items.0.value 1)}}
                             <label class="label-margin-top">{{t question.items.1.description}}</label><br>
                             {{#textarea value=question.items.1.value rows="2" cols="35"}}{{/textarea}}<br>
                             <label class="label-margin-top">{{t question.items.2.description}}</label>
                             {{isp-radio-group options=question.items.2.scale labelTop=question.items.2.labelTop
-                                              labels=question.items.2.labels value=question.items.2.value}}
+                                              labels=question.items.2.labels value=question.items.2.value isRTL=isRTL}}
                             <br>
                         {{/if}}
                         <br>

--- a/exp-player/addon/components/exp-thank-you/component.js
+++ b/exp-player/addon/components/exp-thank-you/component.js
@@ -1,7 +1,13 @@
+import Ember from 'ember';
+
 import layout from './template';
 import ExpFrameBaseComponent from '../../components/exp-frame-base/component';
 
 export default ExpFrameBaseComponent.extend({
+
+    extra: {},
+    isRTL: Ember.computed.alias('extra.isRTL'),
+
     type: 'exp-thank-you',
     layout: layout,
     meta: {

--- a/exp-player/addon/components/isp-radio-group/component.js
+++ b/exp-player/addon/components/isp-radio-group/component.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import layout from './template';
 
 import ExpRadioGroupComponent from '../../components/radio-group/component';
@@ -5,11 +6,35 @@ import ExpRadioGroupComponent from '../../components/radio-group/component';
 export default ExpRadioGroupComponent.extend({
     layout,
     labelTop: null,
+
+    options: null,
     labels: null,
     formatLabel: null,
 
     // In an RTL rendering, draw the radio buttons in reverse order
     isRTL: null,
+
+    optionsItems: Ember.computed('options', 'isRTL', function() {
+        const isRTL = this.get('isRTL');
+        const options = this.get('options') || [];
+
+        if (!isRTL) {
+            return options;
+        } else {
+            return Ember.copy(options, true).reverse();
+        }
+    }),
+
+    labelsItems: Ember.computed('labels', 'isRTL', function() {
+        const isRTL = this.get('isRTL');
+        const labels = this.get('labels') || [];
+
+        if (!isRTL) {
+            return labels;
+        } else {
+            return Ember.copy(labels, true).reverse();
+        }
+    }),
 
     /**
      * Option values that should not be displayed

--- a/exp-player/addon/components/isp-radio-group/component.js
+++ b/exp-player/addon/components/isp-radio-group/component.js
@@ -8,6 +8,9 @@ export default ExpRadioGroupComponent.extend({
     labels: null,
     formatLabel: null,
 
+    // In an RTL rendering, draw the radio buttons in reverse order
+    isRTL: null,
+
     /**
      * Option values that should not be displayed
      * @property hiddenOptions

--- a/exp-player/addon/components/isp-radio-group/template.hbs
+++ b/exp-player/addon/components/isp-radio-group/template.hbs
@@ -1,5 +1,5 @@
 <div class="isp-radio-group">
-    {{#each options as |option|}}
+    {{#each optionsItems as |option|}}
         <label class="text-center label-text {{if formatLabel formatLabel}}">
             {{#if labelTop}}
                 {{#if hiddenOptions}}
@@ -10,7 +10,7 @@
                     {{t option.label}}
                 {{/if}}
                 {{radio-button value=option.value checked=value}}
-                {{#each-in labels as |ratings value|}}
+                {{#each-in labelsItems as |ratings value|}}
                     {{#if (eq value.rating option.label)}}
                         <span class="{{if value.formatClass value.formatClass}}">
                             {{t value.label}}
@@ -18,7 +18,7 @@
                     {{/if}}
                 {{/each-in}}
             {{else}}
-                {{#each-in labels as |ratings value|}}
+                {{#each-in labelsItems as |ratings value|}}
                     {{#if (eq value.rating option.label)}}
                         <span class="{{if value.formatClass value.formatClass}}">
                             {{t value.label}}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-344
https://openscience.atlassian.net/browse/LEI-344

Companion to: https://github.com/CenterForOpenScience/isp/pull/124

## Purpose
Some ISP components need to be RTL-aware, so that things like radio buttons can be drawn in the correct order.

This adds an `extras` field to the `exp-player` to support application-specific customization. ISP uses it to pass `isRTL` to individual components which can act on it as necessary.

Components are intended to be isolated, so use of `controllerFor` would be frowned on.

## Summary of changes
Use a custom exp-player field to pass information about RTL language configuration to the radio button renderer.

If no config is specified, then display the labels in the normal order.

## Testing notes
See companion PR.

Try it with both lookit and ISP.
