### PR TITLE
Simplified RTL support + fixes

### DIFF
--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -14,7 +14,6 @@
                             labels=question.labels
                             formatLabel=question.formatLabel
                             value=question.value
-                            isRTL=isRTL
                         }}
                     {{else if (eq question.type 'select')}}
                         {{select-input options=question.scale value=question.value}}

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -11,7 +11,7 @@
                                 <label>{{t item.description}}</label>
                             {{/if}}
                             {{isp-radio-group options=question.scale labelTop=item.labelTop labels=item.labels
-                                              formatLabel=item.formatLabel value=item.value isRTL=isRTL
+                                              formatLabel=item.formatLabel value=item.value
                             }}
                             <br>
                             <br>
@@ -20,13 +20,13 @@
                         {{select-input options=question.scale value=question.items.0.value}}
                     {{else if (eq question.type 'radio-input')}}
                         {{isp-radio-group options=question.scale formatLabel=question.items.0.formatLabel
-                                          value=question.items.0.value isRTL=isRTL}}
+                                          value=question.items.0.value}}
                         {{#if (eq question.items.0.value 1)}}
                             <label class="label-margin-top">{{t question.items.1.description}}</label><br>
                             {{#textarea value=question.items.1.value rows="2" cols="35"}}{{/textarea}}<br>
                             <label class="label-margin-top">{{t question.items.2.description}}</label>
                             {{isp-radio-group options=question.items.2.scale labelTop=question.items.2.labelTop
-                                              labels=question.items.2.labels value=question.items.2.value isRTL=isRTL}}
+                                              labels=question.items.2.labels value=question.items.2.value}}
                             <br>
                         {{/if}}
                         <br>

--- a/exp-player/addon/components/isp-radio-group/component.js
+++ b/exp-player/addon/components/isp-radio-group/component.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import layout from './template';
 
 import ExpRadioGroupComponent from '../../components/radio-group/component';

--- a/exp-player/addon/components/isp-radio-group/component.js
+++ b/exp-player/addon/components/isp-radio-group/component.js
@@ -11,31 +11,6 @@ export default ExpRadioGroupComponent.extend({
     labels: null,
     formatLabel: null,
 
-    // In an RTL rendering, draw the radio buttons in reverse order
-    isRTL: null,
-
-    optionsItems: Ember.computed('options', 'isRTL', function() {
-        const isRTL = this.get('isRTL');
-        const options = this.get('options') || [];
-
-        if (!isRTL) {
-            return options;
-        } else {
-            return Ember.copy(options, true).reverse();
-        }
-    }),
-
-    labelsItems: Ember.computed('labels', 'isRTL', function() {
-        const isRTL = this.get('isRTL');
-        const labels = this.get('labels') || [];
-
-        if (!isRTL) {
-            return labels;
-        } else {
-            return Ember.copy(labels, true).reverse();
-        }
-    }),
-
     /**
      * Option values that should not be displayed
      * @property hiddenOptions

--- a/exp-player/addon/components/isp-radio-group/template.hbs
+++ b/exp-player/addon/components/isp-radio-group/template.hbs
@@ -1,5 +1,5 @@
 <div class="isp-radio-group">
-    {{#each optionsItems as |option|}}
+    {{#each options as |option|}}
         <label class="text-center label-text {{if formatLabel formatLabel}}">
             {{#if labelTop}}
                 {{#if hiddenOptions}}
@@ -10,7 +10,7 @@
                     {{t option.label}}
                 {{/if}}
                 {{radio-button value=option.value checked=value}}
-                {{#each-in labelsItems as |ratings value|}}
+                {{#each-in labels as |ratings value|}}
                     {{#if (eq value.rating option.label)}}
                         <span class="{{if value.formatClass value.formatClass}}">
                             {{t value.label}}
@@ -18,7 +18,7 @@
                     {{/if}}
                 {{/each-in}}
             {{else}}
-                {{#each-in labelsItems as |ratings value|}}
+                {{#each-in labels as |ratings value|}}
                     {{#if (eq value.rating option.label)}}
                         <span class="{{if value.formatClass value.formatClass}}">
                             {{t value.label}}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-344
Companion to:  TBD

## Purpose
Simplify RTL implementation, and ensure that hebrew site is laid out correctly (right aligned)

## Summary of changes
All text and buttons should be right-aligned for hebrew site

<img width="1356" alt="screen shot 2017-01-09 at 1 49 45 pm" src="https://cloud.githubusercontent.com/assets/2957073/21778710/86ddcdce-d672-11e6-8c4d-ecd1ae51fd97.png">


## Testing notes
tbd
