### PR TITLE
[hold][WIP] Suppress questions in sensitive experimental sites

### DIFF
--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -63,7 +63,7 @@ const questions = [
         scale: [
             {label: 'survey.sections.1.questions.2.options.male', value: 1},
             {label: 'survey.sections.1.questions.2.options.female', value: 2},
-            {label: 'survey.sections.1.questions.2.options.other', value: 3},
+            {label: 'survey.sections.1.questions.2.options.other', value: 3, sensitive: true},
             {label: 'survey.sections.1.questions.2.options.na', value: 4}
         ],
         value: null

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -194,24 +194,27 @@ export default ExpFrameBaseComponent.extend(Validations, {
     extra: {},
     isRTL: Ember.computed.alias('extra.isRTL'),
 
-    showOptional: Ember.computed('questions.9.value', function () {
-        // TODO: This is position-sensitive and many be altered by removing the ethnicity question
-        return this.get('questions')[9].value === 1;
+    showOptional: Ember.computed('questions.@each.value', function () {
+        // The exact position of this question will vary because this survey is modified for sensitive locales
+        const questions = this.get('questions');
+        const item = questions.find(item => item.keyName === 'ReligionYesNo');
+        return item.value === 1;
     }),
     responses: Ember.computed(function () {
-        var questions = this.get('questions');
-        var responses = {};
-        for (var i = 0; i < questions.length; i++) {
-            var keyName = questions[i].keyName;
-            // Questions with string values that should get serialized to integers (since select-input returns a string)
-            // (e.g. "16" --> 16)
+        const questions = this.get('questions');
+        let responses = {};
 
-            // FIXME: Will be sensitive to the "hide question" mechanism- indices will change
-            var parseIntResponses = [0, 1, 7];
-            if (parseIntResponses.includes(i)) {
-                responses[keyName] = parseInt(questions[i].value);
+        // Questions with string values that should get serialized to integers (since select-input returns a string)
+        //   (e.g. "16" --> 16)
+        const specialCaseResponses = ['Age', 'Gender', 'Residence'];
+        for (let i = 0; i < questions.length; i++) {
+            const item = questions[i];
+            const keyName = item.keyName;
+
+            if (specialCaseResponses.includes(keyName)) {
+                responses[keyName] = parseInt(item.value);
             } else {
-                responses[keyName] = questions[i].value;
+                responses[keyName] = item.value;
             }
         }
         return responses;

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -16,16 +16,33 @@ function range(start, stop) {
 
 var generateValidators = function (questions) {
     var validators = {};
-    var presence = validator('presence', {
+    const presence = validator('presence', {
         presence: true,
         ignoreBlank: true,
         message: 'This field is required'
     });
-    for (var q = 0; q < questions.length; q++) {
-        var isOptional = 'optional' in questions[q] && questions[q].optional;
-        if (!isOptional) {
-            var key = 'questions.' + q + '.value';
-            validators[key] = presence;
+    // We can't exclude the question from validation entirely without container access (to query currentUser service)
+    // ...so instead we make sure the validator for that question is silently disabled.
+    const sensitivePresence = validator('presence', {
+        presence: true,
+        disabled() {
+            return this.get('currentUser.isSensitive');
+        },
+        ignoreBlank: true,
+        message: 'This field is required'
+    });
+
+    for (let q = 0; q < questions.length; q++) {
+        const item = questions[q];
+        // Exclude the question from validators if it is optional (no validation needed), or sensitive (not
+        // considered to exist for the purposes of this user)
+        if (!item.optional) {
+            let key = 'questions.' + q + '.value';
+            if (item.sensitive) {
+                validators[key] = sensitivePresence;
+            } else {
+                validators[key] = presence;
+            }
         }
     }
     return validators;
@@ -55,7 +72,8 @@ const questions = [
         question: 'survey.sections.1.questions.3.label',
         keyName: 'Ethnicity',
         type: 'input',
-        value: null
+        value: null,
+        sensitive: true
     },
     {
         question: 'survey.sections.1.questions.4.label',
@@ -158,16 +176,27 @@ const questions = [
 const Validations = buildValidations(generateValidators(questions));
 
 export default ExpFrameBaseComponent.extend(Validations, {
+    currentUser: Ember.inject.service(),
+
     type: 'exp-overview',
     layout: layout,
-    questions: questions,
+    questions: Ember.computed('currentUser.isSensitive', function () {
+        // Remove sensitive questions from the list of things to render (validators for them are disabled separately)
+        const isSensitiveSite = this.get('currentUser.isSensitive');
+        if (isSensitiveSite) {
+            return questions.filter(item => !item.sensitive);
+        } else {
+            return questions;
+        }
+    }),
     pageNumber: 1,
 
     extra: {},
     isRTL: Ember.computed.alias('extra.isRTL'),
 
     showOptional: Ember.computed('questions.9.value', function () {
-        return this.questions[9].value === 1;
+        // TODO: This is position-sensitive and many be altered by removing the ethnicity question
+        return this.get('questions')[9].value === 1;
     }),
     responses: Ember.computed(function () {
         var questions = this.get('questions');
@@ -176,6 +205,8 @@ export default ExpFrameBaseComponent.extend(Validations, {
             var keyName = questions[i].keyName;
             // Questions with string values that should get serialized to integers (since select-input returns a string)
             // (e.g. "16" --> 16)
+
+            // FIXME: Will be sensitive to the "hide question" mechanism- indices will change
             var parseIntResponses = [0, 1, 7];
             if (parseIntResponses.includes(i)) {
                 responses[keyName] = parseInt(questions[i].value);

--- a/exp-player/addon/components/select-input/component.js
+++ b/exp-player/addon/components/select-input/component.js
@@ -3,7 +3,24 @@ import layout from './template';
 
 //h/t http://balinterdi.com/2015/08/29/how-to-do-a-select-dropdown-in-ember-20.html
 export default Ember.Component.extend({
+    currentUser: Ember.inject.service(),
+
     layout,
-    options: null,
-    value: null
+    options: [],
+    value: null,
+
+    displayOptions: Ember.computed('options', 'currentUser.isSensitive', function() {
+        // If operating in a sensitive context, optionally remove any select-item options where the object contains
+        //   a key `sensitive:true`
+        const options = this.get('options');
+        if (!this.get('currentUser.isSensitive')) {
+            return options;
+        }
+        return options.filter(item => !item.sensitive);
+    }),
+
+    init() {
+        this.get('currentUser');  // Ensure that we can set observer on lazy-loaded service injection
+        return this._super(...arguments);
+    }
 });

--- a/exp-player/addon/components/select-input/template.hbs
+++ b/exp-player/addon/components/select-input/template.hbs
@@ -1,6 +1,6 @@
 <select class="form-control auto-width" onchange={{action (mut value) value="target.value"}}>
     <option value="" selected="">{{t 'global.selectUnselected'}}</option>
-    {{#each options as |option|}}
+    {{#each displayOptions as |option|}}
         <option value={{option.value}} selected={{eq value option.value}}>{{t option.label}}</option>
     {{/each}}
 </select>


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-344
Companion to: https://github.com/CenterForOpenScience/isp/pull/127

⚠️ Hold until an arabic translation is ready. This will need very thorough and careful testing to be considered for release.

## Purpose
Exclude certain questions from surveys if the locale is marked sensitive (based on ISP-specific config and ISP-specific currentUser service extension)

## Summary of changes
tbd

## Testing notes
- [ ] Make sure that conditional questions (like "which religion" on the first survey page) still show and hide correctly, even if using a site marked as sensitive.
- [ ] Make sure that marked questions are excluded when using a site ID marked as sensitive.
  - [ ] Try everything you can possibly do to this page to get the field to show when it shouldn't. Sneak in via the back button or URL hacking, break outside the user flow, come back later when already logged in- charge the gates.
- [ ] Make sure that data is serialized correctly, eg integer fields are still integers
