### PR TITLE
Further RTL support: misc pages and card sort UI 

### DIFF
--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -150,10 +150,12 @@ export default ExpFrameBaseComponent.extend({
     buckets2Items: Ember.computed('isRTL', 'buckets2', function() {
         // Display of card sort bins should respect RTL settings
 
-        // FIXME: Buckets2 is a weird data structure, and this only partially reverses the list
+        // Buckets2 is a nested data structure, and we need to reverse both the inner and outer lists
         const buckets2 = this.get('buckets2') || [];
         if (this.get('isRTL')) {
-            return buckets2.slice().reverse();
+            return buckets2.slice().reverse().map(item => ({
+                categories: item.categories.slice().reverse()
+            }));
         } else {
             return buckets2;
         }
@@ -174,22 +176,18 @@ export default ExpFrameBaseComponent.extend({
         //    NineCat: object {rsq29: 8,...}
         // }
         let responses = {};
-        const isRTL = this.get('isRTL');
         let cardSortResponse = this.get('cardSortResponse');
         if (cardSortResponse) {
             responses['ThreeCat'] = {};
-            for (var i = 0; i < cardSortResponse.length; i++) {
-                // The serialization mechanism uses the placement of the bucket in HTML markup (left to right)
-                //   to get the category identifier. This falls apart in RTL locales, where the columns are backwards.
-                const value = isRTL ? (cardSortResponse.length - i) : i + i
-
-                // length-i = rtlindex?
-                for (let card of cardSortResponse[i].cards) {
-                    responses['ThreeCat'][card.id] = value;
+            for (let category of cardSortResponse) {
+                // This block is triggered when passing from the first to the second card sort section
+                for (let card of category.cards) {
+                    responses['ThreeCat'][card.id] = category.id;
                 }
             }
         }
         if (this.get('framePage') === 1) {
+            // This block is triggered when finishing the second card sort section
             cardSortResponse = this.get('buckets2Items');
             responses['NineCat'] = {};
             // Assumption: this unpacks a list of category objects:
@@ -299,15 +297,18 @@ export default ExpFrameBaseComponent.extend({
                     default: [
                         {
                             name: 'qsort.sections.1.categories.uncharacteristic',
-                            cards: []
+                            cards: [],
+                            id : 1
                         },
                         {
                             name: 'qsort.sections.1.categories.neutral',
-                            cards: []
+                            cards: [],
+                            id: 2
                         },
                         {
                             name: 'qsort.sections.1.categories.characteristic',
-                            cards: []
+                            cards: [],
+                            id: 3
                         }
                     ]
                 },

--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -137,6 +137,28 @@ export default ExpFrameBaseComponent.extend({
         return shuffle(formatCards(cards));
     }),
 
+    bucketsItems: Ember.computed('isRTL', 'buckets', function() {
+        // Display of card sort bins should respect RTL settings
+        const buckets = this.get('buckets') || [];
+        if (this.get('isRTL')) {
+            return buckets.slice().reverse();
+        } else {
+            return buckets;
+        }
+    }),
+
+    buckets2Items: Ember.computed('isRTL', 'buckets2', function() {
+        // Display of card sort bins should respect RTL settings
+
+        // FIXME: Buckets2 is a weird data structure, and this only partially reverses the list
+        const buckets2 = this.get('buckets2') || [];
+        if (this.get('isRTL')) {
+            return buckets2.slice().reverse();
+        } else {
+            return buckets2;
+        }
+    }),
+
     freeResponses: Ember.computed(function () {
         return this.get('session.expData')['1-1-free-response']['responses'];
     }),
@@ -144,25 +166,31 @@ export default ExpFrameBaseComponent.extend({
     // Represent the sorted cards in a human-readable format for storage in the database
     responses: Ember.computed(function () {
         // Final data should be returned as {
-        //    cardSort1: object {cardId: categoryId,...}
-        //    cardSort2: object {cardId: categoryId,...}
+        //    ThreeCat: object {cardId: categoryId,...}
+        //    NineCat: object {cardId: categoryId,...}
         // }
         // E.g. {
-        //    cardSort1: object {SomoneCountedon: 3,...}
-        //    cardSort2: object {SomoneCountedon: 8,...}
+        //    ThreeCat: object {rsq28: 3,...}
+        //    NineCat: object {rsq29: 8,...}
         // }
         let responses = {};
+        const isRTL = this.get('isRTL');
         let cardSortResponse = this.get('cardSortResponse');
         if (cardSortResponse) {
             responses['ThreeCat'] = {};
             for (var i = 0; i < cardSortResponse.length; i++) {
+                // The serialization mechanism uses the placement of the bucket in HTML markup (left to right)
+                //   to get the category identifier. This falls apart in RTL locales, where the columns are backwards.
+                const value = isRTL ? (cardSortResponse.length - i) : i + i
+
+                // length-i = rtlindex?
                 for (let card of cardSortResponse[i].cards) {
-                    responses['ThreeCat'][card.id] = i + 1;
+                    responses['ThreeCat'][card.id] = value;
                 }
             }
         }
         if (this.get('framePage') === 1) {
-            cardSortResponse = this.get('buckets2');
+            cardSortResponse = this.get('buckets2Items');
             responses['NineCat'] = {};
             // Assumption: this unpacks a list of category objects:
             // { categories: [ {id: id, cards: [cards]},...] }
@@ -185,20 +213,21 @@ export default ExpFrameBaseComponent.extend({
     }),
 
     isValid: Ember.computed(
-        'buckets2.0.categories.0.cards.[]',
-        'buckets2.0.categories.1.cards.[]',
-        'buckets2.0.categories.2.cards.[]',
-        'buckets2.1.categories.0.cards.[]',
-        'buckets2.1.categories.1.cards.[]',
-        'buckets2.1.categories.2.cards.[]',
-        'buckets2.2.categories.0.cards.[]',
-        'buckets2.2.categories.1.cards.[]',
-        'buckets2.2.categories.2.cards.[]',
+        'buckets2Items.0.categories.0.cards.[]',
+        'buckets2Items.0.categories.1.cards.[]',
+        'buckets2Items.0.categories.2.cards.[]',
+        'buckets2Items.1.categories.0.cards.[]',
+        'buckets2Items.1.categories.1.cards.[]',
+        'buckets2Items.1.categories.2.cards.[]',
+        'buckets2Items.2.categories.0.cards.[]',
+        'buckets2Items.2.categories.1.cards.[]',
+        'buckets2Items.2.categories.2.cards.[]',
         function () {
             if (config.featureFlags.validate) {
-                for (var group = 0; group < this.buckets2.length; group++) {
-                    for (var category = 0; category < this.buckets2[group].categories.length; category++) {
-                        var bucket = this.buckets2[group].categories[category];
+                const buckets2 = this.get('buckets2Items');
+                for (var group = 0; group < buckets2.length; group++) {
+                    for (var category = 0; category < buckets2[group].categories.length; category++) {
+                        var bucket = buckets2[group].categories[category];
                         if (bucket['cards'].length !== bucket['max']) {
                             return false;
                         }
@@ -239,7 +268,7 @@ export default ExpFrameBaseComponent.extend({
         },
         nextPage() {
             if (this.get('allowNext')) {
-                this.set('cardSortResponse', Ember.copy(this.get('buckets'), true));
+                this.set('cardSortResponse', Ember.copy(this.get('bucketsItems'), true));
                 this.send('save');
                 this.set('framePage', 1);
                 this.sendAction('updateFramePage', 1);
@@ -248,7 +277,7 @@ export default ExpFrameBaseComponent.extend({
         },
         previousPage() {
             // clear unsaved data
-            for (let bucket of this.get('buckets')) {
+            for (let bucket of this.get('bucketsItems')) {
                 Ember.set(bucket, 'cards', []);
             }
             this.send('previous');
@@ -393,7 +422,7 @@ export default ExpFrameBaseComponent.extend({
                     buckets.characteristic.push(card);
                 }
             }
-            for (let bucket of this.get('buckets')) {
+            for (let bucket of this.get('bucketsItems')) {
                 let name = bucket.name.split('.').pop();
                 Ember.set(bucket, 'cards', buckets[name]);
             }

--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -127,7 +127,7 @@ export default ExpFrameBaseComponent.extend({
     framePage: 0,
 
     extra: {},
-    isRTL: Ember.computed.alias('extra.isRTL'),
+    isRTL: true, // Ember.computed.alias('extra.isRTL'),
 
     pageNumber: Ember.computed('framePage', function() {
         return this.get('framePage') + 3;
@@ -298,7 +298,7 @@ export default ExpFrameBaseComponent.extend({
                         {
                             name: 'qsort.sections.1.categories.uncharacteristic',
                             cards: [],
-                            id : 1
+                            id: 1
                         },
                         {
                             name: 'qsort.sections.1.categories.neutral',
@@ -423,7 +423,8 @@ export default ExpFrameBaseComponent.extend({
                     buckets.characteristic.push(card);
                 }
             }
-            for (let bucket of this.get('bucketsItems')) {
+            for (let bucket of this.get('buckets')) {
+                // Deserialization is order-dependent
                 let name = bucket.name.split('.').pop();
                 Ember.set(bucket, 'cards', buckets[name]);
             }

--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -127,7 +127,7 @@ export default ExpFrameBaseComponent.extend({
     framePage: 0,
 
     extra: {},
-    isRTL: true, // Ember.computed.alias('extra.isRTL'),
+    isRTL: Ember.computed.alias('extra.isRTL'),
 
     pageNumber: Ember.computed('framePage', function() {
         return this.get('framePage') + 3;

--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -21,18 +21,18 @@
         <h4 class="center">{{t 'qsort.sections.1.itemsLeft' count=cards.length}}</h4>
     {{/if}}
     <div class="row hidden-xs">
-        {{#each buckets as |bucket|}}
+        {{#each bucketsItems as |bucket|}}
             <div class="col-sm-4">
                 <h3 class="bucket-label" style={{height}}>{{t bucket.name}}</h3>
             </div>
         {{/each}}
     </div>
     <div class="row">
-        {{#each buckets as |bucket|}}
+        {{#each bucketsItems as |bucket|}}
             <div class="col-sm-4">
                 <h3 class="bucket-label visible-xs" style={{height}}>{{t bucket.name}}</h3>
                 {{#if (eq framePage 0)}}
-                    {{#draggable-object-target bucket=bucket.cards cards=cards buckets=buckets action='dragCard'}}
+                    {{#draggable-object-target bucket=bucket.cards cards=cards buckets=bucketsItems action='dragCard'}}
                         <div class="well bucket">
                             {{#each bucket.cards as |card|}}
                                 {{#draggable-object content=card}}
@@ -55,7 +55,7 @@
     </div>
     {{#if (eq framePage 1)}}
         <div class="row">
-            {{#each buckets2 as |group|}}
+            {{#each buckets2Items as |group|}}
                 <div class="col-sm-4">
                     <div class="row">
                         {{#each group.categories as |category|}}
@@ -72,7 +72,7 @@
             {{/each}}
         </div>
         <div class="row">
-            {{#each buckets2 as |group|}}
+            {{#each buckets2Items as |group|}}
                 <div class="col-sm-4">
                     <div class="row">
                         {{#each group.categories as |category|}}
@@ -87,7 +87,7 @@
                      (if (eq category.cards.length category.max) 'text-success' 'text-danger') ''}}">
                                     {{category.cards.length}}/{{category.max}}
                                 </h5>
-                                {{#draggable-object-target bucket=category.cards buckets=buckets buckets2=buckets2
+                                {{#draggable-object-target bucket=category.cards buckets=bucketsItems buckets2=buckets2Items
                                                            action="dragCard"}}
                                     <div class="well bucket">
                                         {{#each category.cards as |card|}}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-350
Companion to: https://github.com/CenterForOpenScience/isp/pull/129

## Purpose
Make the card sort form reflect RTL settings. In particular, in an RTL language such as hebrew, the three and nine cat elements should be arranged favorable-->unfavorable- and the serialized responses should still match the specified categories that each card was dropped into.

## Summary of changes
- Change visual layout of card sort form, if RTL language is detected
- Change serialization mechanism to put things in the correct order regardless of the visual layout of the page.

## Testing notes
- Do the study in english. Card sort labels should run left to right. (uncharacteristic -- > characteristic)

- Do the study in hebrew. Labels should run the other direction, as far as you can tell. (characteristic--> uncharacteristic)

- Look at the serialized responses for each. Make sure that a card dragged into uncharacteristic always has a value of 1 for the 3-cat sort, etc (per numbers below)- regardless of whether the box appears on the left or right side of the page.
  - [x] RTL language
  - [x] LTR

- [x] Start a new account, and go through the survey. Finish card sort 1, then click next. DO NOT finish card sort 2. Leave the survey. Come back, resume where you left off, and make sure that cards are filled into the correct boxes. (if you are a developer, complete the survey as LTR, and then do it again as RTL, and verify that even when the user switches the boxes are correct)

- [x] Finish card sort 1 and card sort 2. Confirm that the next button validation displays correctly as appropriate, and allows the next buttons to be clicked only when survey sections are completed.

### Interpreting serialized responses
The codebook is an important guide to understanding the field names in serialized output. These names are not obvious. You will probably want to take a screenshot before hitting "submit".

In the responses: rsq2 is the second item in this list, etc:
https://github.com/abought/exp-addons/blob/a2aa6aa4115cf752cc014b7b5d9f04522b2900c6/exp-player/addon/components/exp-card-sort/component.js#L7-L7

Here is how to see how the "translation label" (internal name) compares to the label that the user sees on a card.

- [Hebrew translation data](https://github.com/abought/isp/blob/dac377b9f6dcf443acb22d27aca0f8f560a93098/app/locales/he/translations.js#L879-L879)

- [English translation data](https://github.com/abought/isp/blob/950b9af9ea76c6a7f99948b2d5fe0a6dc2fb8927/app/locales/en/translations.js#L879-L879)

