### PR TITLE
Fix issues that prevented data from being saved

### DIFF
--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -212,7 +212,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
                             type: 'integer'
                         },
                         'Gender': {
-                            type: 'string'
+                            type: 'integer'
                         },
                         'Ethnicity': {
                             type: 'string'
@@ -230,16 +230,16 @@ export default ExpFrameBaseComponent.extend(Validations, {
                             type: 'string'
                         },
                         'Residence': {
-                            type: 'string'
+                            type: 'integer'
                         },
                         'Religion1to10': { // how religious?
                             type: 'integer'
                         },
                         'ReligionYesNo': { // follows religion?
-                            type: 'string'
+                            type: 'integer'
                         },
                         'ReligionFollow': {  // which religion?
-                            type: 'string'
+                            type: ['string', 'null']
                         }
                     }
                 }


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-364
Companion to: (tbd: pair with experimenter + ISP releases)

## Purpose
Fix an issue that prevented data from being saved when users completed the study on the production server.

This issue stems from the fact that the rules for datatypes had changed, but the staging server was grandfathered in under old rules- unless an experiment is saved via the experimenter edit view, the jamdb validation schema does not get updated.

## Summary of changes
Fix fields where validation was found not to match the actual new datatypes.

The ISP experiment is composed of the following frames. I have reviewed the validation rules for the following:

        "overview",  - has validation, updated
        "free-response", - has validation, appears valid
        "card-sort",  - no special validation serverside
        "rating-form",  - no validation. ("TODO")
        "thank-you"  - no validation needed

## Testing notes
Created a new experiment on staging for the experiment to use:
`589a19283de08a005a7f716c`

Cloned the old ISP experiment, saved the schema locally (with the new frame definitions), thus creating a new experiment that obeyed modern validation rules. Then completed the study.

On a fresh experiment using the old validation rules, this would fail when saving page 1 with 400 errors. On the same experiment resaved after the new rules applied, this works.
