### PR TITLE
Update blueprint to reflect move to pod style components

### DIFF
--- a/exp-player/blueprints/exp-frame/files/addon/components/__name__/component.js
+++ b/exp-player/blueprints/exp-frame/files/addon/components/__name__/component.js
@@ -1,4 +1,4 @@
-import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base';
+import ExpFrameBaseComponent from 'exp-player/components/exp-frame-base/component';
 import layout from './template';
 
 export default ExpFrameBaseComponent.extend({
@@ -10,13 +10,13 @@ export default ExpFrameBaseComponent.extend({
         parameters: {
             type: 'object',
             properties: {
-                // define parameters here
+                // define configurable parameters here
             }
         },
         data: {
             type: 'object',
             properties: {
-                // define data structure here
+                // define data to be sent to the server here
             }
         }
     }


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-362

## Purpose

Fix an issue where frames defined using the `exp-frame` blueprint did not work.

## Summary of changes
Blueprint broke when we moved to pod-style components. Make sure it imports the JS from the correct place.

## Testing notes
The blueprint can be triggered as follows:

`ember generate exp-frame exp-something`

1. Make a new frame locally.
2. Using a version of experimenter with that new frame, try to define an experiment that contains an unrecognized frame. Confirm it fails in the experiment editor window in experimenter.
3. Try to define an experiment that uses the new frame. Confirm it works and displays correctly when you try to run that experiment. (preview mode etc)