### PR TITLE
[rfr] Sample YUIDoc boilerplate

### DIFF
--- a/exp-player/addon/components/exp-frame-base-unsafe/component.js
+++ b/exp-player/addon/components/exp-frame-base-unsafe/component.js
@@ -1,12 +1,31 @@
 import ExpFrameBaseComponent from '../../components/exp-frame-base/component';
 
 /**
+ * @module exp-player
+ * @submodule frames
+ */
+
+/**
  * A modified version of the base frame, specifically designed to allow "unsafe" saves and let the user
  *   advance even if data from this frame did not save
  *
  * The primary use case for this component is experiments that need to move through a series of frames without leaving
  * fullscreen mode: if next is fired as a promise, it does not count as a user interaction event
  *  https://openscience.atlassian.net/browse/LEI-369?focusedCommentId=46133&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-46133
+ *
+  * This frame has no configuration options because all of its logic is internal, and is almost never directly used
+ *   in an experiment. It exports no data. Sample experiment definition usage (provided for completeness):
+ ```json
+ "frames": {
+       "my-sample-frame": {
+         "kind": "exp-base-frame-unsafe"
+       }
+    }
+ * ```
+ *
+ *
+ *  @class ExpFrameBaseUnsafe
+ *  @extends ExpFrameBase
  */
 export default ExpFrameBaseComponent.extend({
     actions: {

--- a/exp-player/addon/components/exp-frame-base/component.js
+++ b/exp-player/addon/components/exp-frame-base/component.js
@@ -2,17 +2,55 @@ import Ember from 'ember';
 
 import config from 'ember-get-config';
 
+/**
+ * @module exp-player
+ * @submodule frames
+ */
+
+/** An abstract component for defining experimenter frames
+ *
+ * This provides common base behavior required for any experiment frame. All experiment frames must extend this one.
+ *
+ * This frame has no configuration options because all of its logic is internal, and is almost never directly used
+ *   in an experiment. It exports no data. Sample experiment definition usage (provided for completeness):
+  ```json
+    "frames": {
+       "my-sample-frame": {
+         "kind": "exp-base-frame"
+       }
+    }
+ * ```
+ *
+ * As a user you will almost never need to insert a component into a template directly- the platform should handle that
+ *   by automatically inserting `exp-player` when your experiment starts.
+ * However, a sample template usage is provided below for completeness.
+ *
+ * ```handlebars
+ *  {{
+      component currentFrameTemplate
+        frameIndex=frameIndex
+        framePage=framePage
+        updateFramePage=(action 'updateFramePage')
+        frameConfig=currentFrameConfig
+        frameContext=currentFrameContext
+
+        session=session
+        experiment=experiment
+
+        next=(action 'next')
+        previous=(action 'previous')
+        saveHandler=(action 'saveFrame')
+        skipone=(action 'skipone')
+        sessionCompleted=(action 'sessionCompleted')
+
+        extra=extra
+    }}
+ * ```
+ * @class ExpFrameBase
+ */
 export default Ember.Component.extend({
-    /** An abstract component for defining experimenter frames
-
-     @property {string} id: the unique identifier for the _instance_
-     @property {string} type: the static class-level type of this frame, e.g.: exp-consent-form
-     @property {object} ctx: a deep copy of the exp-player context
-     @property {integer} ctx.frameIndex: the current exp-player frameIndex
-     **/
-
     toast: Ember.inject.service(),
-
+    // {String} the unique identifier for the _instance_
     id: null,
     kind: null,
 
@@ -30,7 +68,7 @@ export default Ember.Component.extend({
             properties: {}
         }
     },
-
+    // {Number} the current exp-player frameIndex
     frameIndex: null,
     framePage: null,
     frameConfig: null,
@@ -127,6 +165,14 @@ export default Ember.Component.extend({
         return defaultParams;
     },
 
+    /**
+     * The base class does not define any data to save to the server. It does, however, capture some basic event
+     *   timing data. (such as when the user clicks the "next" button)
+     *
+     * @param {Object} eventTimings
+     * @method serializeContent
+     * @return {Object}
+     */
     serializeContent() {
         // Serialize selected parameters for this frame, plus eventTiming data
         var serialized = this.getProperties(Object.keys(this.get('meta.data.properties') || {}));

--- a/exp-player/addon/components/exp-frame-base/component.js
+++ b/exp-player/addon/components/exp-frame-base/component.js
@@ -169,6 +169,9 @@ export default Ember.Component.extend({
      * The base class does not define any data to save to the server. It does, however, capture some basic event
      *   timing data. (such as when the user clicks the "next" button)
      *
+     * This section slightly breaks YUIDoc conventions- rather than being a literal guide to using the code, the
+     *   "parameters" here are abstract descriptions of what data is captured.
+     *
      * @param {Object} eventTimings
      * @method serializeContent
      * @return {Object}

--- a/exp-player/addon/components/exp-player/component.js
+++ b/exp-player/addon/components/exp-player/component.js
@@ -26,7 +26,7 @@ let {
  *   frameIndex=0
  *   fullScreenElementId='expContainer'}}
  * ```
- * @class exp-player
+ * @class ExpPlayer
  */
 export default Ember.Component.extend(FullScreen, {
     layout: layout,
@@ -59,8 +59,8 @@ export default Ember.Component.extend(FullScreen, {
     /**
      * Customize what happens when the user exits the page
      * @method beforeUnload
-     * @parameter {event} event The event to be handled
-     * @returns {String|null} If string is provided, triggers a modal to confirm user wants to leave page
+     * @param {event} event The event to be handled
+     * @return {String|null} If string is provided, triggers a modal to confirm user wants to leave page
      */
     beforeUnload(event) {
         if (!this.get('allowExit')) {

--- a/exp-player/addon/components/exp-video-preview/component.js
+++ b/exp-player/addon/components/exp-video-preview/component.js
@@ -10,7 +10,6 @@ import VideoRecord from '../../mixins/video-record';
  * @submodule frames
  */
 
-
 /**
  * A frame that displays a series of videos to preview, without collecting data as a live experiment.
  ```json

--- a/exp-player/addon/components/exp-video-preview/component.js
+++ b/exp-player/addon/components/exp-video-preview/component.js
@@ -5,6 +5,40 @@ import ExpFrameBaseComponent from '../../components/exp-frame-base/component';
 import MediaReload from '../../mixins/media-reload';
 import VideoRecord from '../../mixins/video-record';
 
+/**
+ * @module exp-player
+ * @submodule frames
+ */
+
+
+/**
+ * A frame that displays a series of videos to preview, without collecting data as a live experiment.
+ ```json
+ "frames": {
+       "my-sample-frame": {
+          "kind": "exp-video-preview",
+         "text": "Some text that is shown to the user",
+         "prompt": "Text of a button prompt",
+         "videos": [
+           {
+             "caption": "User-facing text that appears below the video",
+             "sources": [
+               {
+                 "type": "video/webm",
+                 "src": "https://url.com/example_intro.webm"
+               },
+               {
+                 "type": "video/mp4",
+                 "src": "https://url.com/example_intro.webm"
+               }
+             ]
+           }
+         ]
+    }
+ * ```
+ * @class ExpVideoPreview
+ * @extends ExpFrameBase
+ */
 export default ExpFrameBaseComponent.extend(MediaReload, VideoRecord, {
     layout,
     videoIndex: 0,
@@ -90,6 +124,13 @@ export default ExpFrameBaseComponent.extend(MediaReload, VideoRecord, {
                     type: 'integer',
                     default: 0
                 },
+                /**
+                 * A series of preview videos to display within a single frame, defined as an array of objects.
+                 *
+                 * @property {Array} videos
+                 *   @param {String} caption Some text to appear under this video
+                 *   @param {Object[]} sources Array of {src: 'url', type: 'MIMEtype'} objects.
+                 */
                 videos: {
                     type: 'array',
                     description: 'A list of videos to preview',
@@ -124,6 +165,11 @@ export default ExpFrameBaseComponent.extend(MediaReload, VideoRecord, {
                     },
                     default: []
                 },
+                /**
+                 * Text of the button prompt asking the user to continue
+                 *
+                 * @property {String} prompt
+                 */
                 prompt: {
                     type: 'object',
                     description: 'Require a button press before showing the videos',
@@ -137,6 +183,11 @@ export default ExpFrameBaseComponent.extend(MediaReload, VideoRecord, {
                     },
                     default: null
                 },
+                /**
+                 * Informational text to display to the user
+                 *
+                 * @property {String} text
+                 */
                 text: {
                     type: 'string',
                     description: 'Text to display to the user',
@@ -147,6 +198,14 @@ export default ExpFrameBaseComponent.extend(MediaReload, VideoRecord, {
         },
         data: {
             type: 'object',
+            /**
+             * Parameters captured and sent to the server
+             *
+             * @method serializeContent
+             * @param {String} videoID The ID of any video recorded during this frame
+             * @param {Object} eventTimings
+             * @return {Object} The payload sent to the server
+             */
             properties: {
                 videoId: {
                     type: 'string'

--- a/exp-player/addon/components/isp-radio-group/component.js
+++ b/exp-player/addon/components/isp-radio-group/component.js
@@ -10,7 +10,7 @@ export default ExpRadioGroupComponent.extend({
     labels: null,
     formatLabel: null,
 
-    /**
+    /*
      * Option values that should not be displayed
      * @property hiddenOptions
      * @type: {Array}

--- a/exp-player/addon/mixins/full-screen.js
+++ b/exp-player/addon/mixins/full-screen.js
@@ -4,14 +4,28 @@ let {
     $
 } = Ember;
 
-/*
- Allow components to specify fullscreen capabilities based on minimal configuration options
+/**
+ * @module exp-player
+ * @submodule mixins
+ */
+
+/**
+ * Allow components to specify fullscreen capabilities based on minimal configuration options
+ * @class FullScreen
  */
 export default Ember.Mixin.create({
-    fullScreenElementId: null, // String containing the ID of the element to make full screen
-    displayFullscreen: false,  // Whether to show this element in fullscreen mode by default
+    /**
+     *  The element ID of the thing to make full screen (video element, div, etc)
+     * @property {String} fullScreenElementId
+     */
+    fullScreenElementId: null,
+    displayFullscreen: false,
 
-    fsButtonID: false, // ID for button element to show if user leaves FS
+    /**
+     * The element ID of a button to show if the user leaves fullscreen mode
+     * @property {String} fsButtonID
+     */
+    fsButtonID: false,
 
     // Note: to avoid handler being called repeatedly (bubbling
     // up?) I'm just having components that extend FullScreen call
@@ -72,6 +86,10 @@ export default Ember.Mixin.create({
     },
 
     actions: {
+        /**
+         * Make a specified element fullscreen
+         * @method showFullscreen
+         */
         showFullscreen: function () {
 
             if (!this.get('displayFullscreen')) {
@@ -106,7 +124,10 @@ export default Ember.Mixin.create({
             Ember.$(document).off('webkitfullscreenchange mozfullscreenchange fullscreenchange MSFullscreenChange');
             Ember.$(document).on('webkitfullscreenchange mozfullscreenchange fullscreenchange MSFullscreenChange', this.onFullscreen.bind(this, selector, buttonSel));
         },
-
+        /**
+         * Exit fullscreen mode
+         * @method exitFullscreen
+         */
         exitFullscreen: function () {
             console.log('exiting FS mode');
             if (document.exitFullscreen) {

--- a/exp-player/addon/mixins/media-reload.js
+++ b/exp-player/addon/mixins/media-reload.js
@@ -1,14 +1,21 @@
 import Ember from 'ember';
 
-/*
- Allow any media-containing component to correctly reset.
- Fix LEI-93, an issue where the second of two consecutive videos did not play correctly.
+/**
+ * @module exp-player
+ * @submodule mixins
+ */
 
-  Due to an internal ember quirk/optimization, the component instance is not destroyed if two of the same thing are
-  used in a row, which means the same video tag was being dynamically reassigned- something HTML does not normally
-  allow. The page needs to be manually told to load the correct new video.
+/**
+ * Allow any media-containing frame to correctly reset.
+ * Fix LEI-93, an issue where the second of two consecutive videos did not play correctly.
 
- See commentary here: http://stackoverflow.com/a/18454389/1422268
+ * Due to an internal ember quirk/optimization, the component instance is not destroyed if two of the same thing are
+ *  used in a row, which means the same video tag was being dynamically reassigned- something HTML does not normally
+ * allow. The page needs to be manually told to load the correct new video.
+ *
+ * See commentary here: http://stackoverflow.com/a/18454389/1422268
+ *
+ * @class MediaReload
  */
 export default Ember.Mixin.create({
     mediaTags: ['audio', 'video'],

--- a/exp-player/addon/mixins/video-record.js
+++ b/exp-player/addon/mixins/video-record.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 /**
- * @module experimenter
+ * @module exp-player
  * @submodule mixins
  */
 
@@ -13,8 +13,8 @@ import Ember from 'ember';
 export default Ember.Mixin.create({
 
     /**
-     * @property videoRecorder Automatically injects the video recorder service, making its methods available to your
-     * component
+     * This mixin automatically injects the video recorder service, making its methods available to your frame
+     * @property videoRecorder
      */
     videoRecorder: Ember.inject.service(),
 

--- a/exp-player/addon/randomizers/next.js
+++ b/exp-player/addon/randomizers/next.js
@@ -1,4 +1,4 @@
-/**
+/*
  *  WARNING: This is provided solely on an example basis.  It represents unused code and may require revisions to
  *    run according to the newest design of the platform.
  */

--- a/exp-player/addon/randomizers/pref-phys-pilot.js
+++ b/exp-player/addon/randomizers/pref-phys-pilot.js
@@ -17,7 +17,7 @@ function shuffleArray(array) {
  *
  * @method getLastSession
  * @param {Session[]} pastSessions An array of session records. This returns the first match, eg assumes newest-first sort order
- * @returns {Session} The model representing the last session in which the user participated
+ * @return {Session} The model representing the last session in which the user participated
  */
 function getLastSession(pastSessions) {
     // Base randomization on the newest (last completed) session for which the participant got at

--- a/exp-player/addon/randomizers/pref-phys.js
+++ b/exp-player/addon/randomizers/pref-phys.js
@@ -17,7 +17,7 @@ function shuffleArray(array) {
  *
  * @method getLastSession
  * @param {Session[]} pastSessions An array of session records. This returns the first match, eg assumes newest-first sort order
- * @returns {Session} The model representing the last session in which the user participated
+ * @return {Session} The model representing the last session in which the user participated
  */
 function getLastSession(pastSessions) {
     // Base randomization on the newest (last completed) session for which the participant got at

--- a/exp-player/addon/randomizers/random.js
+++ b/exp-player/addon/randomizers/random.js
@@ -2,7 +2,7 @@
  NOTE: you will need to manually add an entry for this file in addon/randomizers/index.js
  */
 
-/**
+/*
  *  WARNING: This is provided solely on an example basis.  It represents unused code and may require revisions to
  *    run according to the newest design of the platform.
  */

--- a/exp-player/addon/randomizers/rotate.js
+++ b/exp-player/addon/randomizers/rotate.js
@@ -2,7 +2,7 @@
  NOTE: you will need to manually add an entry for this file in addon/randomizers/index.js
  */
 
-/**
+/*
  *  WARNING: This is provided solely on an example basis.  It represents unused code and may require revisions to
  *    run according to the newest design of the platform.
  */

--- a/exp-player/addon/randomizers/shuffle.js
+++ b/exp-player/addon/randomizers/shuffle.js
@@ -2,15 +2,15 @@
  NOTE: you will need to manually add an entry for this file in addon/randomizers/index.js
  */
 
-/**
+/*
  *  WARNING: This is provided solely on an example basis.  It represents unused code and may require revisions to
  *    run according to the newest design of the platform.
  */
 var randomizer = function (frame, _, resolveFrame) {
-    /**
+    /*
      * Randomize array element order in-place.
      * Using Durstenfeld shuffle algorithm.
-     **/
+     */
     var array = frame.options.slice();
     for (var i = array.length - 1; i > 0; i--) {
         var j = Math.floor(Math.random() * (i + 1));

--- a/exp-player/addon/services/video-recorder.js
+++ b/exp-player/addon/services/video-recorder.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 /**
- * @module experimenter
+ * @module exp-player
  * @submodule services
  */
 
@@ -232,7 +232,7 @@ const VideoRecorder = Ember.Object.extend({
     /**
      * Get a timestamp based on the current recording position. Useful to ensure that tracked timing events
      *  line up with the video.
-     *
+     * @method getTime
      * @return {Date|null}
      */
     getTime() {
@@ -292,8 +292,8 @@ const VideoRecorder = Ember.Object.extend({
     /**
      * Show the recorder to the user. Useful if you want to temporarily show a hidden recorder- eg to let the user fix
      *   a problem with video capture settings
-     *
-     * @returns {boolean}
+     * @method show
+     * @return {boolean}
      */
     show() {
         this.get('$container').removeClass('video-recorder-hidden');

--- a/exp-player/addon/utils/parse-experiment.js
+++ b/exp-player/addon/utils/parse-experiment.js
@@ -17,17 +17,17 @@ var ExperimentParser = function (context = {
     this.sequence = context.structure.sequence;
 
 };
-/** Modifies the data in the experiment schema definition to match
+/* Modifies the data in the experiment schema definition to match
  * the format expected by exp-player
- **/
+ */
 ExperimentParser.prototype._reformatFrame = function (frame, index) {
     var newConfig = Ember.copy(frame, true);
     newConfig.id = `${index}-${frame.id}`;
     return newConfig;
 };
-/** Convert a random frame to a list of constituent
+/* Convert a random frame to a list of constituent
  * frame config objects
- **/
+ */
 ExperimentParser.prototype._resolveRandom = function (frame, frameId) {
     var randomizer = frame.sampler || 'random';  // Random sampling by default
     if (!randomizers[randomizer]) {
@@ -63,17 +63,17 @@ ExperimentParser.prototype._resolveDependencies = function (frame) {
     });
     return frame;
 };
-/** Convert a block of frames to an array of constituent frame config objects
- **/
+/* Convert a block of frames to an array of constituent frame config objects
+ */
 ExperimentParser.prototype._resolveBlock = function (frame) {
     return [
         frame.items.map((frameId) => this._resolveFrame(frameId)),
         null
     ];
 };
-/** Convert any frame to a list of constituent frame config objects.
+/* Convert any frame to a list of constituent frame config objects.
  * Centrally dispatches logic for all other frame types
- **/
+ */
 ExperimentParser.prototype._resolveFrame = function (frameId, frame) {
     frame = frame || this.frames[frameId];
     if (frameNamePattern.test(frame.kind)) {

--- a/exp-player/addon/yuidoc-prose.js
+++ b/exp-player/addon/yuidoc-prose.js
@@ -1,10 +1,35 @@
 // Prose for YUIDoc: define text used in module descriptions
 
 /**
+ * Reusable components for UI rendering and interactivity
+ *
+ * @module exp-player
+ * @submodule components
+ * @main
+ */
+
+/**
  * Reusable frames that can be used as part of user-defined experiments. This is the main reference for researchers
  *   looking to build their own experiment definitions on the experimenter platform.
  *
- @module exp-player
- @submodule frames
- @main
+ * @module exp-player
+ * @submodule frames
+ * @main
  */
+
+/**
+ * Mixins that can be used to add functionality, eg to a specific frame
+ *
+ * @module exp-player
+ * @submodule mixins
+ * @main
+ */
+
+/**
+ * Services used to share data or provide centralized functionality
+ *
+ * @module exp-player
+ * @submodule services
+ * @main
+ */
+

--- a/exp-player/addon/yuidoc-prose.js
+++ b/exp-player/addon/yuidoc-prose.js
@@ -1,0 +1,10 @@
+// Prose for YUIDoc: define text used in module descriptions
+
+/**
+ * Reusable frames that can be used as part of user-defined experiments. This is the main reference for researchers
+ *   looking to build their own experiment definitions on the experimenter platform.
+ *
+ @module exp-player
+ @submodule frames
+ @main
+ */

--- a/exp-player/package.json
+++ b/exp-player/package.json
@@ -3,16 +3,20 @@
   "version": "0.0.1",
   "description": "The Experimenter player and associated components",
   "directories": {
-    "doc": "doc",
+    "doc": "docs",
     "test": "tests"
   },
   "scripts": {
+    "docs": "yuidoc --lint && yuidoc",
     "build": "ember build",
     "start": "ember server",
     "test": "yarn run check-style && ember test",
     "check-style": "./node_modules/jscs/bin/jscs ."
   },
-  "repository": "",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/CenterForOpenScience/exp-addons.git"
+  },
   "engines": {
     "node": ">=6"
   },

--- a/exp-player/package.json
+++ b/exp-player/package.json
@@ -14,8 +14,8 @@
     "check-style": "./node_modules/jscs/bin/jscs ."
   },
   "repository": {
-      "type": "git",
-      "url": "https://github.com/CenterForOpenScience/exp-addons.git"
+    "type": "git",
+    "url": "https://github.com/CenterForOpenScience/exp-addons.git"
   },
   "engines": {
     "node": ">=6"
@@ -56,7 +56,8 @@
     "jscs": "^3.0.7",
     "loader.js": "^4.0.1",
     "moment": "2.13.0",
-    "moment-timezone": "0.5.4"
+    "moment-timezone": "0.5.4",
+    "yuidocjs": "^0.10.2"
   },
   "keywords": [
     "ember-addon"

--- a/exp-player/yarn.lock
+++ b/exp-player/yarn.lock
@@ -172,9 +172,17 @@ asap@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
 
+asn1@0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.1.11.tgz#559be18376d08a4ec4dbe80877d27818639b2df7"
+
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
+
+assert-plus@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.1.5.tgz#ee74009413002d84cec7219c6ac811812e723160"
 
 assert-plus@^0.2.0:
   version "0.2.0"
@@ -230,9 +238,17 @@ async@^2.0.1:
   dependencies:
     lodash "^4.14.0"
 
+async@~0.9.0:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
+aws-sign2@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.5.0.tgz#c57103f7a17fc037f02d7c2e64b602ea223f7d63"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -480,6 +496,12 @@ body-parser@~1.14.0:
     qs "5.2.0"
     raw-body "~2.1.5"
     type-is "~1.6.10"
+
+boom@0.4.x:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-0.4.2.tgz#7a636e9ded4efcefb19cef4947a3c67dfaee911b"
+  dependencies:
+    hoek "0.9.x"
 
 boom@2.x.x:
   version "2.10.1"
@@ -1080,6 +1102,12 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+combined-stream@~0.0.4:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-0.0.7.tgz#0137e657baa5a7541c57ac37ac5fc07d73b4dc1f"
+  dependencies:
+    delayed-stream "0.0.5"
+
 commander@2.8.x:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
@@ -1268,6 +1296,12 @@ cross-spawn@^5.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cryptiles@0.2.x:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-0.2.2.tgz#ed91ff1f17ad13d3748288594f8a48a0d26f325c"
+  dependencies:
+    boom "0.4.x"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -1281,6 +1315,10 @@ cst@^0.4.3:
     babel-runtime "^6.9.2"
     babylon "^6.8.1"
     source-map-support "^0.4.0"
+
+ctype@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/ctype/-/ctype-0.5.3.tgz#82c18c2461f74114ef16c135224ad0b9144ca12f"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -1362,6 +1400,10 @@ defs@~1.1.0:
     stringset "~0.2.1"
     tryor "~0.1.2"
     yargs "~3.27.0"
+
+delayed-stream@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-0.0.5.tgz#d4b1f43a93e8296dfe02694f4680bc37a313c73f"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2235,7 +2277,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-express@^4.10.7, express@^4.12.3:
+express@^4.10.7, express@^4.12.3, express@^4.13.1:
   version "4.14.0"
   resolved "https://registry.yarnpkg.com/express/-/express-4.14.0.tgz#c1ee3f42cdc891fb3dc650a8922d51ec847d0d66"
   dependencies:
@@ -2404,9 +2446,21 @@ for-own@^0.1.4:
   dependencies:
     for-in "^0.1.5"
 
+forever-agent@~0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.5.2.tgz#6d0e09c4921f94a27f63d3b49c5feff1ea4c5130"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+
+form-data@~0.1.0:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-0.1.4.tgz#91abd788aba9702b1aabfa8bc01031a2ac9e3b12"
+  dependencies:
+    async "~0.9.0"
+    combined-stream "~0.0.4"
+    mime "~1.2.11"
 
 form-data@~1.0.0-rc3:
   version "1.0.1"
@@ -2773,6 +2827,15 @@ hash-for-dep@^1.0.2:
     heimdalljs-logger "^0.1.7"
     resolve "^1.1.6"
 
+hawk@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-1.1.1.tgz#87cd491f9b46e4e2aeaca335416766885d2d1ed9"
+  dependencies:
+    boom "0.4.x"
+    cryptiles "0.2.x"
+    hoek "0.9.x"
+    sntp "0.2.x"
+
 hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -2800,6 +2863,10 @@ heimdalljs@^0.3.0:
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.3.2.tgz#d19f98cf7c6a7660c2ecbbeaa696db3436227713"
   dependencies:
     rsvp "~3.2.1"
+
+hoek@0.9.x:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-0.9.1.tgz#3d322462badf07716ea7eb85baf88079cddce505"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -2847,6 +2914,14 @@ http-proxy@^1.13.1, http-proxy@^1.9.0:
   dependencies:
     eventemitter3 "1.x.x"
     requires-port "1.x.x"
+
+http-signature@~0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-0.10.1.tgz#4fbdac132559aa8323121e540779c0a012b27e66"
+  dependencies:
+    asn1 "0.1.11"
+    assert-plus "^0.1.5"
+    ctype "0.5.3"
 
 http-signature@~1.1.0:
   version "1.1.1"
@@ -3225,7 +3300,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.0, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -3630,7 +3705,7 @@ markdown-it@7.0.0:
     mdurl "^1.0.1"
     uc.micro "^1.0.1"
 
-markdown-it@^4.4.0:
+markdown-it@^4.3.0, markdown-it@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-4.4.0.tgz#3df373dbea587a9a7fef3e56311b68908f75c414"
   dependencies:
@@ -3669,6 +3744,10 @@ md5-hex@^1.0.2:
 md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
+
+mdn-links@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/mdn-links/-/mdn-links-0.1.0.tgz#e24c83b97cb4c5886cc39f2f780705fbfe273aa5"
 
 mdurl@^1.0.1, mdurl@~1.0.0:
   version "1.0.1"
@@ -3739,9 +3818,17 @@ mime-types@^2.1.11, mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, 
   dependencies:
     mime-db "~1.26.0"
 
+mime-types@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-1.0.2.tgz#995ae1392ab8affcbfcb2641dd054e943c0d5dce"
+
 mime@1.3.4, mime@^1.2.11:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
+
+mime@~1.2.11:
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
 
 minimatch@1:
   version "1.0.0"
@@ -3957,7 +4044,7 @@ node-sass@^3.4.1:
     request "^2.61.0"
     sass-graph "^2.1.1"
 
-node-uuid@^1.4.3, node-uuid@~1.4.7:
+node-uuid@^1.4.3, node-uuid@~1.4.0, node-uuid@~1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
 
@@ -4137,6 +4224,10 @@ npm@2.15.5:
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+
+oauth-sign@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.3.0.tgz#cb540f93bb2b22a7d5941691a288d60e8ea9386e"
 
 oauth-sign@~0.8.1:
   version "0.8.2"
@@ -4430,6 +4521,10 @@ qs@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
 
+qs@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-1.0.2.tgz#50a93e2b5af6691c31bcea5dae78ee6ea1903768"
+
 qs@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-5.1.0.tgz#4d932e5c7ea411cca76a312d39a606200fd50cd9"
@@ -4722,6 +4817,25 @@ request@2, request@^2.27.0, request@^2.47.0, request@^2.61.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
+request@~2.40.0:
+  version "2.40.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.40.0.tgz#4dd670f696f1e6e842e66b4b5e839301ab9beb67"
+  dependencies:
+    forever-agent "~0.5.0"
+    json-stringify-safe "~5.0.0"
+    mime-types "~1.0.1"
+    node-uuid "~1.4.0"
+    qs "~1.0.0"
+  optionalDependencies:
+    aws-sign2 "~0.5.0"
+    form-data "~0.1.0"
+    hawk "1.1.1"
+    http-signature "~0.10.0"
+    oauth-sign "~0.3.0"
+    stringstream "~0.0.4"
+    tough-cookie ">=0.12.0"
+    tunnel-agent "~0.4.0"
+
 request@~2.72.0:
   version "2.72.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.72.0.tgz#0ce3a179512620b10441f14c82e21c12c0ddb4e1"
@@ -4793,7 +4907,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.2, rimraf@^2.5.3, rimraf@~2.5.2:
+rimraf@2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.1, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.2, rimraf@^2.5.3, rimraf@~2.5.2:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
@@ -4977,6 +5091,12 @@ slash@^1.0.0:
 slide@^1.1.3, slide@^1.1.5, slide@~1.1.3, slide@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+
+sntp@0.2.x:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/sntp/-/sntp-0.2.4.tgz#fb885f18b0f3aad189f824862536bceeec750900"
+  dependencies:
+    hoek "0.9.x"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -5327,15 +5447,15 @@ to-single-quotes@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/to-single-quotes/-/to-single-quotes-2.0.1.tgz#7cc29151f0f5f2c41946f119f5932fe554170125"
 
-tough-cookie@~2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.2.2.tgz#c83a1830f4e5ef0b93ef2a3488e724f8de016ac7"
-
-tough-cookie@~2.3.0:
+tough-cookie@>=0.12.0, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
+
+tough-cookie@~2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.2.2.tgz#c83a1830f4e5ef0b93ef2a3488e724f8de016ac7"
 
 tree-sync@^1.1.0:
   version "1.2.2"
@@ -5363,7 +5483,7 @@ tryor@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/tryor/-/tryor-0.1.2.tgz#8145e4ca7caff40acde3ccf946e8b8bb75b4172b"
 
-tunnel-agent@~0.4.1:
+tunnel-agent@~0.4.0, tunnel-agent@~0.4.1:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
 
@@ -5735,3 +5855,21 @@ yargs@~3.27.0:
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+
+yui@^3.18.1:
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/yui/-/yui-3.18.1.tgz#e000269ec0a7b6fbc741cbb8fcbd0e65117b014c"
+  dependencies:
+    request "~2.40.0"
+
+yuidocjs@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/yuidocjs/-/yuidocjs-0.10.2.tgz#33924967ce619024cd70ef694e267d2f988f73f6"
+  dependencies:
+    express "^4.13.1"
+    graceful-fs "^4.1.2"
+    markdown-it "^4.3.0"
+    mdn-links "^0.1.0"
+    minimatch "^3.0.2"
+    rimraf "^2.4.1"
+    yui "^3.18.1"

--- a/exp-player/yuidoc.json
+++ b/exp-player/yuidoc.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/CenterForOpenScience/exp-addons",
+    "options": {
+        "linkNatives": "true",
+        "attributesEmit": "true",
+        "paths": [
+            "addon"
+        ],
+        "outdir": "docs/"
+    }
+}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-377

## Purpose
Add the ability to create auto-generated text documentation, especially for user-facing frames.

## Summary of changes
Add YUIDoc configuration and build commands. Add a demonstration of recommended practices for documenting three components:
- The base frame
- One frame that inherits the base, without changing input parameters or serialized data
- One frame that inherits the base, and changes both input parameters and serialized data

Also improve existing documentation to the minimum standard needed for it to show up in generated docs and build correctly. 

![screen shot 2017-02-27 at 1 06 08 pm](https://cloud.githubusercontent.com/assets/2957073/23373379/bc9337a0-fced-11e6-81ed-f55973d957a9.png)


### Rules
YUIDoc is based solely on the docstrings you give it. If you omit a docstring, a method won't appear in the docs. If you use annotate a method as a property, it will go with what you tell it.

It will often ignore method or property declarations unless you first specify a class.  Likewise, it may omit classes that do not define an associated module at the top of the file. Since most frames `@extend` a class, in practice this works fine.

YUIDoc insists that its docstrings have a very specific [syntax](http://yui.github.io/yuidoc/syntax/): 
```
/**
 * First line must have two asterisks, to differentiate documentation from 
 * other sorts of multiline source code comment
 */
```
In the strictest sense, not every basic JS concept translates perfectly into the way experimenter does things. To shoehorn this into something we can document, I have adopted a convention that all configurable frame properties are documented as `@property` strings, and all fields that are captured and serialized as part of data collection are defined as `@param`s of the `@method serializeContent`. Any frame that collects data will need to override `serializeContent`.

(note that *every* frame will capture `eventTimings`. We are definitely abusing YUIDoc syntax for this method!)

## Testing notes
Within the `exp-player` directory, you can preview the documentation (and auto-rebuild when docstrings change) by running the following command:

`yuidoc --server`

Then visit a specific page, like the `frames` section of the documentation:
`http://127.0.0.1:3000/modules/frames.html`

## Deployment notes
The simplest path to deployment would be using [github pages](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/) to deploy built documentation. We will hold off on doing this for now so as to avoid exposing preliminary/ unmaintained docs that are a work in progress.

Also considered [readthedocs](http://read-the-docs.readthedocs.io/en/latest/getting_started.html#write-your-docs), but this does not appear to support YUIDoc. It works well for python tools like sphinx, and is fine for prose, but doesn't seem to play as well with javascript documentation.