### PR TITLE
Show validation messages in form

### DIFF
--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -3,6 +3,8 @@ import ExpFrameBaseComponent from '../../components/exp-frame-base/component';
 import layout from './template';
 import config from 'ember-get-config';
 
+import ScrollToMixin from '../../mixins/scroll-to';
+
 // jscs:disable requireDotNotation
 var cards = [
     'qsort.rsq.item.potentiallyEnjoy',
@@ -121,7 +123,7 @@ var shuffle = function (array) {
     return array;
 };
 
-export default ExpFrameBaseComponent.extend({
+export default ExpFrameBaseComponent.extend(ScrollToMixin, {
     type: 'exp-card-sort',
     layout: layout,
     framePage: 0,
@@ -281,6 +283,9 @@ export default ExpFrameBaseComponent.extend({
                     })
                     .catch(err => this.displayError(err));
 
+            } else {
+                // Let page rerender (to show validation errors), then scroll to the first one
+                Ember.run.scheduleOnce('afterRender', this, () => this.send('scrollTo', '.validation-error'));
             }
         },
         previousPage() {

--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -129,6 +129,8 @@ export default ExpFrameBaseComponent.extend({
     extra: {},
     isRTL: Ember.computed.alias('extra.isRTL'),
 
+    showValidations: false,
+
     pageNumber: Ember.computed('framePage', function() {
         return this.get('framePage') + 3;
     }),
@@ -265,6 +267,9 @@ export default ExpFrameBaseComponent.extend({
             target.unshiftObject(card);
         },
         nextPage() {
+            // Only show validations once button has been clicked at least once
+            this.set('showValidations', true);
+
             if (this.get('allowNext')) {
                 this.set('cardSortResponse', Ember.copy(this.get('bucketsItems'), true));
                 this._save()
@@ -272,8 +277,10 @@ export default ExpFrameBaseComponent.extend({
                         this.set('framePage', 1);
                         this.sendAction('updateFramePage', 1);
                         window.scrollTo(0, 0);
+                        this.set('showValidations', false);
                     })
                     .catch(err => this.displayError(err));
+
             }
         },
         previousPage() {
@@ -284,6 +291,8 @@ export default ExpFrameBaseComponent.extend({
             this.send('previous');
         },
         continue() {
+            // Only show validations once button has been clicked at least once
+            this.set('showValidations', true);
             if (this.get('isValid')) {
                 this.send('next');
             }

--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -300,6 +300,9 @@ export default ExpFrameBaseComponent.extend(ScrollToMixin, {
             this.set('showValidations', true);
             if (this.get('isValid')) {
                 this.send('next');
+            } else {
+                // Let page rerender (to show validation errors), then scroll to the first one
+                Ember.run.scheduleOnce('afterRender', this, () => this.send('scrollTo', '.validation-error'));
             }
         }
     },

--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -120,7 +120,7 @@
                 {{t 'global.continueLabel'}}
             </button>
             {{#if (and showValidations (not allowNext))}}
-                <span class="text-danger"><i class="fa fa-exclamation-triangle"></i></span>
+                <i class="fa fa-exclamation-triangle text-danger" aria-label="Please complete all required fields (*) to continue."></i>
             {{/if}}
         </div>
     {{else if (eq framePage 1)}}
@@ -129,7 +129,7 @@
                 {{t 'global.continueLabel'}}
             </button>
             {{#if (and showValidations (not isValid))}}
-                <i class="fa fa-exclamation-triangle text-danger" aria-label="Please fill out all required fields (*) to continue."></i>
+                <i class="fa fa-exclamation-triangle text-danger" aria-label="Please complete all required fields (*) to continue."></i>
             {{/if}}
         </div>
     {{/if}}

--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -18,7 +18,7 @@
                 {{/draggable-object}}
             {{/each}}
         </div>
-        <h4 class="center {{if (and showValidations (not allowNext)) 'text-danger'}}">{{t 'qsort.sections.1.itemsLeft' count=cards.length}}</h4>
+        <h4 class="center {{if (and showValidations (not allowNext)) 'text-danger validation-error'}}">{{t 'qsort.sections.1.itemsLeft' count=cards.length}}</h4>
     {{/if}}
     <div class="row hidden-xs">
         {{#each bucketsItems as |bucket|}}
@@ -77,7 +77,7 @@
                     <div class="row">
                         {{#each group.categories as |category|}}
                             <div class="col-sm-4 small-bucket
-                                {{unless (eq category.cards.length category.max) 'text-danger'}}
+                                {{unless (eq category.cards.length category.max) 'text-danger validation-error'}}
                                 ">
                                 <h5 class="bucket-label visible-xs {{if
                                     (eq category.name 'qsort.sections.2.categories.neutral') ''
@@ -119,18 +119,12 @@
             <button class="btn btn-primary" {{action "nextPage"}}>
                 {{t 'global.continueLabel'}}
             </button>
-            {{#if (and showValidations (not allowNext))}}
-                <i class="fa fa-exclamation-triangle text-danger" aria-label="Please complete all required fields (*) to continue."></i>
-            {{/if}}
         </div>
     {{else if (eq framePage 1)}}
         <div class="pull-right">
             <button class="btn btn-primary" {{ action 'continue' }}>
                 {{t 'global.continueLabel'}}
             </button>
-            {{#if (and showValidations (not isValid))}}
-                <i class="fa fa-exclamation-triangle text-danger" aria-label="Please complete all required fields (*) to continue."></i>
-            {{/if}}
         </div>
     {{/if}}
     {{progress-bar pageNumber=pageNumber}}

--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -18,7 +18,7 @@
                 {{/draggable-object}}
             {{/each}}
         </div>
-        <h4 class="center">{{t 'qsort.sections.1.itemsLeft' count=cards.length}}</h4>
+        <h4 class="center {{if (and showValidations (not allowNext)) 'text-danger'}}">{{t 'qsort.sections.1.itemsLeft' count=cards.length}}</h4>
     {{/if}}
     <div class="row hidden-xs">
         {{#each bucketsItems as |bucket|}}
@@ -76,15 +76,15 @@
                 <div class="col-sm-4">
                     <div class="row">
                         {{#each group.categories as |category|}}
-                            <div class="col-sm-4 small-bucket">
+                            <div class="col-sm-4 small-bucket
+                                {{unless (eq category.cards.length category.max) 'text-danger'}}
+                                ">
                                 <h5 class="bucket-label visible-xs {{if
                                     (eq category.name 'qsort.sections.2.categories.neutral') ''
                                     'bucket-label-margin'}}">
                                     {{t category.name}}
                                 </h5>
-                                <h5 class="text-center
-                {{if (gte category.cards.length category.max)
-                     (if (eq category.cards.length category.max) 'text-success' 'text-danger') ''}}">
+                                <h5 class="text-center">
                                     {{category.cards.length}}/{{category.max}}
                                 </h5>
                                 {{#draggable-object-target bucket=category.cards buckets=bucketsItems buckets2=buckets2Items
@@ -115,13 +115,23 @@
         <button class="btn btn-default" {{ action 'previousPage' }}>
             {{t 'global.previousLabel'}}
         </button>
-        <button class="btn btn-primary pull-right {{if allowNext '' 'disabled'}}" {{action "nextPage"}}>
-            {{t 'global.continueLabel'}}
-        </button>
+        <div class="pull-right">
+            <button class="btn btn-primary" {{action "nextPage"}}>
+                {{t 'global.continueLabel'}}
+            </button>
+            {{#if (and showValidations (not allowNext))}}
+                <span class="text-danger"><i class="fa fa-exclamation-triangle"></i></span>
+            {{/if}}
+        </div>
     {{else if (eq framePage 1)}}
-        <button class="btn btn-primary pull-right {{if isValid '' 'disabled'}}" {{ action 'continue' }}>
-            {{t 'global.continueLabel'}}
-        </button>
+        <div class="pull-right">
+            <button class="btn btn-primary" {{ action 'continue' }}>
+                {{t 'global.continueLabel'}}
+            </button>
+            {{#if (and showValidations (not isValid))}}
+                <i class="fa fa-exclamation-triangle text-danger" aria-label="Please fill out all required fields (*) to continue."></i>
+            {{/if}}
+        </div>
     {{/if}}
     {{progress-bar pageNumber=pageNumber}}
 </div>

--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -36,6 +36,8 @@ export default ExpFrameBaseComponent.extend(Validations, {
     extra: {},
     isRTL: Ember.computed.alias('extra.isRTL'),
 
+    showValidations: false,
+
     diff1: Ember.computed('WhatResponse', function () {
         var length = getLength(this.get('WhatResponse'));
         var message = this.get('i18n').t('survey.sections.2.questions.11.characterCount').string;
@@ -140,6 +142,7 @@ export default ExpFrameBaseComponent.extend(Validations, {
     },
     actions: {
         continue() {
+            this.set('showValidations', true);
             if (this.get('allowNext')) {
                 this.send('next');
             }

--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -5,6 +5,7 @@ import {validator, buildValidations} from 'ember-cp-validations';
 import config from 'ember-get-config';
 
 import ExpFrameBaseComponent from '../../components/exp-frame-base/component';
+import ScrollToMixin from '../../mixins/scroll-to';
 
 function getLength(value) {
     var length = 0;
@@ -27,7 +28,7 @@ const Validations = buildValidations({
     EventTime: presence
 });
 
-export default ExpFrameBaseComponent.extend(Validations, {
+export default ExpFrameBaseComponent.extend(Validations, ScrollToMixin, {
     type: 'exp-free-response',
     layout: layout,
     i18n: Ember.inject.service(),

--- a/exp-player/addon/components/exp-free-response/component.js
+++ b/exp-player/addon/components/exp-free-response/component.js
@@ -145,6 +145,9 @@ export default ExpFrameBaseComponent.extend(Validations, {
             this.set('showValidations', true);
             if (this.get('allowNext')) {
                 this.send('next');
+            } else {
+                // Let page rerender (to show validation errors), then scroll to the first one
+                Ember.run.scheduleOnce('afterRender', this, () => this.send('scrollTo', '.validation-error'));
             }
         }
     },

--- a/exp-player/addon/components/exp-free-response/template.hbs
+++ b/exp-player/addon/components/exp-free-response/template.hbs
@@ -11,8 +11,10 @@
         }}
             <label class="control-label">
                 {{t 'survey.sections.2.questions.14.label'}}
-                {{#if showValidations}}
-                    {{unless (v-get this 'EventTime' 'isValid') '*'}}
+                {{#if (and showValidations
+                          (not (v-get this 'EventTime' 'isValid'))
+                      )}}
+                    <span class="validation-error">*</span>
                 {{/if}}
             </label><br>
             <div id="timeSelect" dir="ltr"> {{! Prevent date display from being mangled in RTL languages- TODO improve fix }}
@@ -54,8 +56,10 @@
         }}
             <label class="control-label">
                 {{t 'survey.sections.2.questions.12.label'}}
-                {{#if showValidations}}
-                    {{unless (v-get this 'WhereResponse' 'isValid') '*'}}
+                {{#if (and showValidations
+                          (not (v-get this 'WhereResponse' 'isValid'))
+                      )}}
+                    <span class="validation-error">*</span>
                 {{/if}}
             </label>
             {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=WhereResponse}}{{/textarea}}
@@ -67,8 +71,10 @@
         }}
             <label class="control-label">
                 {{t 'survey.sections.2.questions.13.label'}}
-                {{#if showValidations}}
-                    {{unless (v-get this 'WhoResponse' 'isValid') '*'}}
+                {{#if (and showValidations
+                          (not (v-get this 'WhoResponse' 'isValid'))
+                      )}}
+                    <span class="validation-error">*</span>
                 {{/if}}
             </label>
             {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=WhoResponse}}{{/textarea}}

--- a/exp-player/addon/components/exp-free-response/template.hbs
+++ b/exp-player/addon/components/exp-free-response/template.hbs
@@ -39,8 +39,10 @@
         }}
             <label class="control-label">
                 {{t 'survey.sections.2.questions.11.label'}}
-                {{#if showValidations}}
-                    {{unless (v-get this 'WhatResponse' 'isValid') '*'}}
+                {{#if (and showValidations
+                          (not (v-get this 'WhatResponse' 'isValid'))
+                      )}}
+                    <span class="validation-error">*</span>
                 {{/if}}
             </label>
             {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=WhatResponse}}{{/textarea}}
@@ -82,9 +84,6 @@
         <button class="btn btn-primary" {{ action 'continue' }}>
             {{t 'global.continueLabel'}}
         </button>
-        {{#if (and showValidations (not this.validations.isValid))}}
-            <i class="fa fa-exclamation-triangle text-danger" aria-label="Please complete all required fields (*) to continue."></i>
-        {{/if}}
     </div>
     {{progress-bar pageNumber=pageNumber}}
 </div>

--- a/exp-player/addon/components/exp-free-response/template.hbs
+++ b/exp-player/addon/components/exp-free-response/template.hbs
@@ -5,10 +5,19 @@
         <span>{{t 'survey.sections.2.instructions.secondSection'}}</span>
     </p>
     {{#bs-form}}
-        {{#bs-form-group}}
-            <label>{{t 'survey.sections.2.questions.14.label'}}</label><br>
+        {{#bs-form-group
+            validation=(if showValidations (unless (v-get this 'EventTime' 'isValid') "error"))
+            useIcons=false
+        }}
+            <label class="control-label">
+                {{t 'survey.sections.2.questions.14.label'}}
+                {{#if showValidations}}
+                    {{unless (v-get this 'EventTime' 'isValid') '*'}}
+                {{/if}}
+            </label><br>
             <div id="timeSelect" dir="ltr"> {{! Prevent date display from being mangled in RTL languages- TODO improve fix }}
                 {{#power-select
+                    class='form-control'
                     dropdownClass='dropdownClass'
                     selected=EventTime
                     options=times
@@ -24,18 +33,42 @@
             </div>
         {{/bs-form-group}}
         <p>{{t 'survey.sections.2.instructions.thirdSection'}}</p>
-        {{#bs-form-group}}
-            <label>{{t 'survey.sections.2.questions.11.label'}}</label>
+        {{#bs-form-group
+            validation=(if showValidations (unless (v-get this 'WhatResponse' 'isValid') "error"))
+            useIcons=false
+        }}
+            <label class="control-label">
+                {{t 'survey.sections.2.questions.11.label'}}
+                {{#if showValidations}}
+                    {{unless (v-get this 'WhatResponse' 'isValid') '*'}}
+                {{/if}}
+            </label>
             {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=WhatResponse}}{{/textarea}}
             <p class="text-muted">{{diff1}}</p>
         {{/bs-form-group}}
-        {{#bs-form-group}}
-            <label>{{t 'survey.sections.2.questions.12.label'}}</label>
+        {{#bs-form-group
+            useIcons=false
+            validation=(if showValidations (unless (v-get this 'WhereResponse' 'isValid') "error"))
+        }}
+            <label class="control-label">
+                {{t 'survey.sections.2.questions.12.label'}}
+                {{#if showValidations}}
+                    {{unless (v-get this 'WhereResponse' 'isValid') '*'}}
+                {{/if}}
+            </label>
             {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=WhereResponse}}{{/textarea}}
             <p class="text-muted">{{diff2}}</p>
         {{/bs-form-group}}
-        {{#bs-form-group}}
-            <label>{{t 'survey.sections.2.questions.13.label'}}</label>
+        {{#bs-form-group
+            useIcons=false
+            validation=(if showValidations (unless (v-get this 'WhoResponse' 'isValid') "error"))
+        }}
+            <label class="control-label">
+                {{t 'survey.sections.2.questions.13.label'}}
+                {{#if showValidations}}
+                    {{unless (v-get this 'WhoResponse' 'isValid') '*'}}
+                {{/if}}
+            </label>
             {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=WhoResponse}}{{/textarea}}
             <p class="text-muted">{{diff3}}</p>
         {{/bs-form-group}}
@@ -45,8 +78,13 @@
     <button class="btn btn-default" {{ action 'previous' }}>
         {{t 'global.previousLabel'}}
     </button>
-    <button class="btn btn-primary pull-right {{if allowNext "" "disabled"}}" {{ action 'continue' }}>
-        {{t 'global.continueLabel'}}
-    </button>
+    <div class="pull-right">
+        <button class="btn btn-primary" {{ action 'continue' }}>
+            {{t 'global.continueLabel'}}
+        </button>
+        {{#if (and showValidations (not this.validations.isValid))}}
+            <i class="fa fa-exclamation-triangle text-danger" aria-label="Please complete all required fields (*) to continue."></i>
+        {{/if}}
+    </div>
     {{progress-bar pageNumber=pageNumber}}
 </div>

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -169,6 +169,9 @@ export default ExpFrameBaseComponent.extend(Validations, {
     extra: {},
     isRTL: Ember.computed.alias('extra.isRTL'),
 
+    // Hide validations until the first time the user clicks "continue"
+    showValidations: false,
+
     showOptional: Ember.computed('questions.9.value', function () {
         return this.questions[9].value === 1;
     }),
@@ -251,6 +254,9 @@ export default ExpFrameBaseComponent.extend(Validations, {
     },
     actions: {
         continue() {
+            // Do not show validations until first time user clicks "next"
+            this.set('showValidations', true);
+
             if (this.get('allowNext')) {
                 this.send('next');
             }

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -21,6 +21,9 @@ var generateValidators = function (questions) {
         ignoreBlank: true,
         message: 'This field is required'
     });
+
+    // Due to a quirk of how validations are defined, we must manually create the validation key in the
+    //  template. If the validation mechanism in the component changes, the template must also change.
     for (var q = 0; q < questions.length; q++) {
         var isOptional = 'optional' in questions[q] && questions[q].optional;
         if (!isOptional) {

--- a/exp-player/addon/components/exp-overview/component.js
+++ b/exp-player/addon/components/exp-overview/component.js
@@ -5,6 +5,7 @@ import {validator, buildValidations} from 'ember-cp-validations';
 import config from 'ember-get-config';
 
 import ExpFrameBaseComponent from '../../components/exp-frame-base/component';
+import ScrollToMixin from '../../mixins/scroll-to';
 
 function range(start, stop) {
     var options = [];
@@ -160,7 +161,7 @@ const questions = [
 
 const Validations = buildValidations(generateValidators(questions));
 
-export default ExpFrameBaseComponent.extend(Validations, {
+export default ExpFrameBaseComponent.extend(Validations, ScrollToMixin, {
     type: 'exp-overview',
     layout: layout,
     questions: questions,
@@ -259,6 +260,9 @@ export default ExpFrameBaseComponent.extend(Validations, {
 
             if (this.get('allowNext')) {
                 this.send('next');
+            } else {
+                // Let page rerender (to show validation errors), then scroll to the first one
+                Ember.run.scheduleOnce('afterRender', this, () => this.send('scrollTo', '.validation-error'));
             }
         }
     },

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -6,7 +6,7 @@
             {{! Due to a quirk of how validations are defined, we must manually create the validation key in the
             template. If the validation mechanism in the component changes, the template must also change }}
             {{#bs-form-group
-                validation=(if showValidations (if (v-get this (concat 'questions.' index '.value') 'isValid') "success" "error"))
+                validation=(if showValidations (unless (v-get this (concat 'questions.' index '.value') 'isValid') "error"))
                 useIcons=false
             }}
                 {{#unless question.optional}}
@@ -45,7 +45,7 @@
             {{t 'global.continueLabel'}}
         </button>
         {{#if (and showValidations (not this.validations.isValid))}}
-            <span class="text-danger">*</span>
+            <i class="fa fa-exclamation-triangle text-danger" aria-label="Please fill out all required fields (*) to continue."></i>
         {{/if}}
     </div>
     {{progress-bar pageNumber=pageNumber}}

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -2,10 +2,17 @@
     {{page-number pageNumber=pageNumber}}
     <p class="break-line">{{t 'survey.sections.1.instructions'}}</p>
     {{#bs-form}}
-        {{#each questions as |question|}}
-            {{#bs-form-group}}
+        {{#each questions as |question index|}}
+            {{! Due to a quirk of how validations are defined, we must manually create the validation key in the
+            template. If the validation mechanism in the component changes, the template must also change }}
+            {{#bs-form-group
+                validation=(if (v-get this (concat 'questions.' index '.value') 'isValid') "success" "error")
+                useIcons=false
+            }}
                 {{#unless question.optional}}
-                    <label>{{t question.question}}</label>
+                    <label class="control-label">
+                        {{t question.question}}{{unless (v-get this (concat 'questions.' index '.value') 'isValid') '*'}}
+                    </label>
                     {{#if (eq question.type 'radio')}}
                         {{isp-radio-group
                             options=question.scale
@@ -18,11 +25,11 @@
                     {{else if (eq question.type 'select')}}
                         {{select-input options=question.scale value=question.value}}
                     {{else if (eq question.type 'input')}}
-                        {{#input class="form-control auto-width" value=question.value}}{{/input}}
+                        {{input class="form-control auto-width" value=question.value}}
                     {{/if}}
                 {{else if showOptional}}
                     <label>{{t question.question}}</label>
-                    {{#input value=question.value}}{{/input}}
+                    {{input value=question.value}}
                 {{/unless}}
             {{/bs-form-group}}
         {{/each}}

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -13,7 +13,9 @@
                     <label class="control-label">
                         {{t question.question}}
                         {{#if showValidations}}
-                            {{unless (v-get this (concat 'questions.' index '.value') 'isValid') '*'}}
+                            {{#unless (v-get this (concat 'questions.' index '.value') 'isValid')}}
+                                <span class="validation-error">*</span>
+                            {{/unless}}
                         {{/if}}
                     </label>
                     {{#if (eq question.type 'radio')}}
@@ -39,13 +41,10 @@
     {{/bs-form}}
 </div>
 <div class="row exp-controls">
-    <div class="pull-right">
+    <span class="pull-right">
         <button class="btn btn-primary" {{ action 'continue' }}>
             {{t 'global.continueLabel'}}
         </button>
-        {{#if (and showValidations (not this.validations.isValid))}}
-            <i class="fa fa-exclamation-triangle text-danger" aria-label="Please complete all required fields (*) to continue."></i>
-        {{/if}}
-    </div>
+    </span>
     {{progress-bar pageNumber=pageNumber}}
 </div>

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -6,12 +6,16 @@
             {{! Due to a quirk of how validations are defined, we must manually create the validation key in the
             template. If the validation mechanism in the component changes, the template must also change }}
             {{#bs-form-group
-                validation=(if (v-get this (concat 'questions.' index '.value') 'isValid') "success" "error")
+                validation=(if showValidations (if (v-get this (concat 'questions.' index '.value') 'isValid') "success" "error"))
                 useIcons=false
             }}
                 {{#unless question.optional}}
                     <label class="control-label">
-                        {{t question.question}}{{unless (v-get this (concat 'questions.' index '.value') 'isValid') '*'}}
+                        {{t question.question}}
+                        {{#if showValidations}}
+                            {{unless (v-get this (concat 'questions.' index '.value') 'isValid') '*'}}
+                        {{/if}}
+
                     </label>
                     {{#if (eq question.type 'radio')}}
                         {{isp-radio-group
@@ -36,8 +40,13 @@
     {{/bs-form}}
 </div>
 <div class="row exp-controls">
-    <button class="btn btn-primary pull-right {{if allowNext  "" "disabled"}}" {{ action 'continue' }}>
-        {{t 'global.continueLabel'}}
-    </button>
+    <div class="pull-right">
+        <button class="btn btn-primary" {{ action 'continue' }}>
+            {{t 'global.continueLabel'}}
+        </button>
+        {{#if (and showValidations (not this.validations.isValid))}}
+            <span class="text-danger">*</span>
+        {{/if}}
+    </div>
     {{progress-bar pageNumber=pageNumber}}
 </div>

--- a/exp-player/addon/components/exp-overview/template.hbs
+++ b/exp-player/addon/components/exp-overview/template.hbs
@@ -15,7 +15,6 @@
                         {{#if showValidations}}
                             {{unless (v-get this (concat 'questions.' index '.value') 'isValid') '*'}}
                         {{/if}}
-
                     </label>
                     {{#if (eq question.type 'radio')}}
                         {{isp-radio-group
@@ -45,7 +44,7 @@
             {{t 'global.continueLabel'}}
         </button>
         {{#if (and showValidations (not this.validations.isValid))}}
-            <i class="fa fa-exclamation-triangle text-danger" aria-label="Please fill out all required fields (*) to continue."></i>
+            <i class="fa fa-exclamation-triangle text-danger" aria-label="Please complete all required fields (*) to continue."></i>
         {{/if}}
     </div>
     {{progress-bar pageNumber=pageNumber}}

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -229,7 +229,6 @@ var generateValidators = function (questions) {
             on: pages[number]
         });
     }
-    debugger;
     return validators;
 };
 
@@ -726,7 +725,6 @@ export default ExpFrameBaseComponent.extend(Validations, ScrollToMixin, {
         continue() {
             this.set('showValidations', true);
 
-            //if (false) { // todo: revert
             if (this.get('allowNext')) {
                 if (this.get('framePage') !== this.get('lastPage')) {
                     this._save()

--- a/exp-player/addon/components/exp-rating-form/component.js
+++ b/exp-player/addon/components/exp-rating-form/component.js
@@ -5,6 +5,7 @@ import {validator, buildValidations} from 'ember-cp-validations';
 import config from 'ember-get-config';
 
 import ExpFrameBaseComponent from '../../components/exp-frame-base/component';
+import ScrollToMixin from '../../mixins/scroll-to';
 
 // jscs:disable requireDotNotation
 var items = {
@@ -203,6 +204,8 @@ const SEVEN_POINT_SCALE = TEN_POINT_SCALE.slice(1, 8);
 const NINE_POINT_SCALE = TEN_POINT_SCALE.slice(1, 10);
 
 var generateValidators = function (questions) {
+    // The template contains specific assumptions about how validator keynames are constructed.
+    //   If this code is changed, the template will also need to be changed
     var validators = {};
     var pages = {};
     for (var i = 0; i < questions.length; i++) {
@@ -226,6 +229,7 @@ var generateValidators = function (questions) {
             on: pages[number]
         });
     }
+    debugger;
     return validators;
 };
 
@@ -645,7 +649,7 @@ var questions = [
 
 const Validations = buildValidations(generateValidators(questions));
 
-export default ExpFrameBaseComponent.extend(Validations, {
+export default ExpFrameBaseComponent.extend(Validations, ScrollToMixin, {
     type: 'exp-rating-form',
     layout: layout,
     framePage: 0,
@@ -653,6 +657,8 @@ export default ExpFrameBaseComponent.extend(Validations, {
 
     extra: {},
     isRTL: Ember.computed.alias('extra.isRTL'),
+
+    showValidations: false,
 
     progressBarPage: Ember.computed('framePage', function () {
         return this.framePage + 5;
@@ -718,13 +724,16 @@ export default ExpFrameBaseComponent.extend(Validations, {
             window.scrollTo(0, 0);
         },
         continue() {
+            this.set('showValidations', true);
+
+            //if (false) { // todo: revert
             if (this.get('allowNext')) {
                 if (this.get('framePage') !== this.get('lastPage')) {
-
                     this._save()
                         .then(() => {
-                            var page = this.get('framePage') + 1;
+                            const page = this.get('framePage') + 1;
                             this.set('framePage', page);
+                            this.set('showValidations', false);
                             this.sendAction('updateFramePage', page);
                             window.scrollTo(0, 0);
                         })
@@ -733,6 +742,9 @@ export default ExpFrameBaseComponent.extend(Validations, {
                     this.sendAction('sessionCompleted');
                     this.send('next');
                 }
+            } else {
+                // Let page rerender (to show validation errors), then scroll to the first one
+                Ember.run.scheduleOnce('afterRender', this, () => this.send('scrollTo', '.validation-error'));
             }
         }
     },

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -4,11 +4,31 @@
         {{#each questions as |question index|}}
             {{#if (eq question.page framePage)}}
                 {{#bs-form-group}}
-                    <label class="break-line question-label">{{add index 1}}. {{t question.question}}</label><br>
+                    <label class="break-line question-label {{unless (eq question.items.length 1) 'control-label'}}">
+                        {{#if (and
+                                  (eq question.items.length 1)
+                                  (not (v-get this (concat 'page.' framePage '.questions.' index  '.items.' 0 '.value') 'isValid'))
+                        )}}
+                            {{! A form group here can be one question, or many. Only color the label if response invalid,
+                                this is a single question (only items.0 exists), AND we want to show validations
+                                This is a hack that hardcodes all kinds of assumptions based on how validators are constructed, etc etc etc etc etc
+                            }}
+                            {{! FIXME: Refactor so that validators are exposed, and can actually be checked in template }}
+                            <span class="validation-error text-danger">{{add index 1}}. {{t question.question}} *</span>
+                        {{else}}
+                            {{add index 1}}. {{t question.question}}
+                        {{/if}}
+                    </label><br>
                     {{#if (eq question.type 'radio')}}
-                        {{#each question.items as |item|}}
+                        {{#each question.items as |item itemIndex|}}
                             {{#if item.description}}
-                                <label>{{t item.description}}</label>
+                                <label class="control-label">
+                                    {{#if (v-get this (concat 'page.' framePage '.questions.' index  '.items.' itemIndex '.value') 'isValid')}}
+                                        {{t item.description}}
+                                    {{else}}
+                                        <span class="validation-error text-danger">{{t item.description}} *</span>
+                                    {{/if}}
+                                </label>
                             {{/if}}
                             {{isp-radio-group options=question.scale labelTop=item.labelTop labels=item.labels
                                               formatLabel=item.formatLabel value=item.value
@@ -23,7 +43,7 @@
                                           value=question.items.0.value}}
                         {{#if (eq question.items.0.value 1)}}
                             <label class="label-margin-top">{{t question.items.1.description}}</label><br>
-                            {{#textarea value=question.items.1.value rows="2" cols="35"}}{{/textarea}}<br>
+                            {{textarea value=question.items.1.value rows="2" cols="35"}}<br>
                             <label class="label-margin-top">{{t question.items.2.description}}</label>
                             {{isp-radio-group options=question.items.2.scale labelTop=question.items.2.labelTop
                                               labels=question.items.2.labels value=question.items.2.value}}
@@ -37,14 +57,16 @@
     {{/bs-form}}
 </div>
 <div class="row exp-controls">
-    <button class='btn btn-primary pull-right {{if allowNext "" "disabled"}}' {{action 'continue'}}>
-        {{t
-        'global.continueLabel'}}
-    </button>
     {{#unless (eq framePage 0)}}
         <button class="btn btn-default" {{ action 'previousPage' }}>
             {{t 'global.previousLabel'}}
         </button>
     {{/unless}}
+    <span class="pull-right">
+        <button class='btn btn-primary' {{action 'continue'}}>
+            {{t
+                'global.continueLabel'}}
+        </button>
+    </span>
     {{progress-bar pageNumber=progressBarPage}}
 </div>

--- a/exp-player/addon/components/exp-rating-form/template.hbs
+++ b/exp-player/addon/components/exp-rating-form/template.hbs
@@ -6,14 +6,14 @@
                 {{#bs-form-group}}
                     <label class="break-line question-label {{unless (eq question.items.length 1) 'control-label'}}">
                         {{#if (and
+                                  showValidations
                                   (eq question.items.length 1)
-                                  (not (v-get this (concat 'page.' framePage '.questions.' index  '.items.' 0 '.value') 'isValid'))
+                                  (not (v-get this (concat 'questions.' index  '.items.' 0 '.value') 'isValid'))
                         )}}
                             {{! A form group here can be one question, or many. Only color the label if response invalid,
                                 this is a single question (only items.0 exists), AND we want to show validations
                                 This is a hack that hardcodes all kinds of assumptions based on how validators are constructed, etc etc etc etc etc
                             }}
-                            {{! FIXME: Refactor so that validators are exposed, and can actually be checked in template }}
                             <span class="validation-error text-danger">{{add index 1}}. {{t question.question}} *</span>
                         {{else}}
                             {{add index 1}}. {{t question.question}}
@@ -23,10 +23,13 @@
                         {{#each question.items as |item itemIndex|}}
                             {{#if item.description}}
                                 <label class="control-label">
-                                    {{#if (v-get this (concat 'page.' framePage '.questions.' index  '.items.' itemIndex '.value') 'isValid')}}
-                                        {{t item.description}}
-                                    {{else}}
+                                    {{#if (and showValidations
+                                              (not (v-get this (concat 'questions.' index  '.items.' itemIndex '.value') 'isValid')))
+                                    }}
                                         <span class="validation-error text-danger">{{t item.description}} *</span>
+
+                                    {{else}}
+                                        {{t item.description}}
                                     {{/if}}
                                 </label>
                             {{/if}}

--- a/exp-player/addon/mixins/scroll-to.js
+++ b/exp-player/addon/mixins/scroll-to.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+/**
+ * Provide reusable action for scrolling to the position of the specified element
+ */
+export default Ember.Mixin.create({
+    actions: {
+        scrollTo(selector) {
+            Ember.$('html, body').scrollTop(this.$(selector).offset().top);
+        }
+    }
+});


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/SVCS-299
Companion to:  TBD

(ISP will need a PR to update submodule)

## Purpose
This is an ISP PR. It does not affect Lookit code, as it goes to a separate branch.

Currently, it can be hard to find which fields still need to be filled out. Show multi-lingual cross-cultural validation messages to users, without adding new text that needs to be translated. 

## Summary of changes
- Provide a way for users to see which fields are missing or incomplete on each page of the survey
- Fix a bug where the card sort validation did not show errors if the user had *too many* cards in the bin (on card sort section 2, "Nine category")

<img width="817" alt="screen shot 2017-05-03 at 5 41 25 pm" src="https://cloud.githubusercontent.com/assets/2957073/25684937/225a2c66-3032-11e7-9960-cd138c6b62ec.png">
<img width="712" alt="screen shot 2017-05-03 at 5 35 42 pm" src="https://cloud.githubusercontent.com/assets/2957073/25684942/29722332-3032-11e7-89b9-0d98cdee4a7f.png">


## Testing notes
- The continue button is now always enabled on every page, but it will not advance until all fields are filled out
- On first page view, fields are shown normally. If the user clicks "continue" or "next" with missing/invalid fields, this will trigger validation to appear, and autoscroll the screen to the location of the first error
  - Most errors will be shown in red, and marked with an asterisk.
  - The error should disappear as soon as the field is filled in
  - Clicking continue will autoscroll to an error. If you fix that error and click continue again, it will scroll to the next error (if there is one), or advance to the next page (once validation is passing)
  - If there is a form control such as a dropdown, the dropdown will also be outlined in red
  - Card sort pages do not have specific labels, so we simply show the label above the card bin in red
  - On the final rating form (long list of radio button questions), there can be ~3 levels of headings. Only the most specific heading should show the validation error, pertaining to that specific data field. Eg if question 4 has 10 parts, the "question 4" summary prompt should not show a validation error.
- We cannot add a sentence describing the validation error, because text would need to be translated.

## TODO
- Fine grained control over labels on survey form (labels can be one or more questions, so some refactoring of the template may be needed)
Improve UX
- [x] Autoscroll to first error via jquery
- [x] Remove exclamation icon in favor of autoscroll
- [x] Refine placement and coloring of labels
- [x] Write QA testing plan