### PR TITLE
fix problem with random-parameter-set randomizer where the first roun…

### DIFF
--- a/exp-player/addon/components/exp-lookit-dialogue-page/component.js
+++ b/exp-player/addon/components/exp-lookit-dialogue-page/component.js
@@ -512,6 +512,7 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
 
     audioObserver: Ember.observer('readyToStartAudio', function(frame) {
         if (frame.get('readyToStartAudio')) {
+            $('#waitForVideo').hide();
             frame.set('currentAudioIndex', -1);
             frame.send('playNextAudioSegment');
         }

--- a/exp-player/addon/components/exp-lookit-dialogue-page/template.hbs
+++ b/exp-player/addon/components/exp-lookit-dialogue-page/template.hbs
@@ -4,6 +4,10 @@
 <div class="exp-lookit-dialogue-page" id="exp-lookit-dialogue-page-container">
 
     <div id="story-area">
+        {{#if doRecording}}
+            <p id='waitForVideo'> establishing video connection <br> please wait... </p>
+        {{/if}}
+
 
         {{#each images as |image|}}
             <div id={{image.id}} class="story-image-container" onclick={{action 'clickSpeaker' image.id}} style="left:{{image.left}}%; height:{{image.height}}%; bottom:{{image.bottom}}%;">

--- a/exp-player/addon/components/exp-video-config/template.hbs
+++ b/exp-player/addon/components/exp-video-config/template.hbs
@@ -28,7 +28,7 @@
         {{#if showWebCamWarning }}
             <h4 class="text-warning">
                 We couldn't connect to your webcam. Please make sure you have a webcam connected
-                and <button class="btn btn-default" {{action 'reloadRecorder'}}>reload</button>
+                and <button class="btn btn-default" {{action 'reloadRecorder'}}>click here to detect</button>
             </h4>
         {{/if}}
 
@@ -44,8 +44,8 @@
 
                 <li>
                     <p>
-                        To check that your privacy settings are working, click
-                        <button class="btn btn-primary" {{action 'reloadRecorder'}}>reload</button>
+                        To check that your privacy settings are working, click this button:
+                        <button class="btn btn-primary" {{action 'reloadRecorder'}}>check settings</button>
                         . You should see your webcam view again in a moment, <em>without</em> having to click "Allow."
                         If you were prompted again, this time make sure to also click the "Remember" box," and try
                         reloading again.
@@ -67,7 +67,7 @@
 
         {{#if showWarning}}
             <div class="reload-warning">
-                * Please try reloading the webcam view to check your privacy settings are working.
+                * Please click 'check settings' above to make sure your privacy settings are set correctly. You should see your webcam view again in a moment, without having to click "Allow" again (see step 2).
             </div>
         {{/if}}
 

--- a/exp-player/addon/randomizers/random-parameter-set.js
+++ b/exp-player/addon/randomizers/random-parameter-set.js
@@ -3,6 +3,8 @@
 * @submodule randomizers
 */
 
+import Ember from 'ember';
+
 /**
 * Randomizer to implement flexible condition assignment and counterbalancing by
 * allowing the user to specify an arbitrary sequence of frames to create. A
@@ -318,11 +320,11 @@ var randomizer = function(frameId, frameConfig, pastSessions, resolveFrame) {
         // don't affect the original frameConfig values if they're objects
         // themselves!!
         thisFrame = {};
-        $.extend(true, thisFrame, frameConfig.commonFrameProperties);
+        Ember.$.extend(true, thisFrame, frameConfig.commonFrameProperties);
 
         // Assign parameters specific to this frame (allow to override
         // common parameters assigned above)
-        $.extend(true, thisFrame, frameConfig.frameList[iFrame]);
+        Ember.$.extend(true, thisFrame, frameConfig.frameList[iFrame]);
 
         // Substitute any properties that can be replaced based on
         // the parameter set.

--- a/exp-player/addon/randomizers/random-parameter-set.js
+++ b/exp-player/addon/randomizers/random-parameter-set.js
@@ -313,13 +313,16 @@ var randomizer = function(frameId, frameConfig, pastSessions, resolveFrame) {
 
     for (var iFrame = 0; iFrame < frameConfig.frameList.length; iFrame++) {
 
-        // Assign parameters common to all frames made by this randomizer
+        // Assign parameters common to all frames made by this randomizer.
+        // Use deep copies to make sure that substitutions (replaceValues)
+        // don't affect the original frameConfig values if they're objects
+        // themselves!!
         thisFrame = {};
-        Object.assign(thisFrame, frameConfig.commonFrameProperties);
+        $.extend(true, thisFrame, frameConfig.commonFrameProperties);
 
         // Assign parameters specific to this frame (allow to override
         // common parameters assigned above)
-        Object.assign(thisFrame, frameConfig.frameList[iFrame]);
+        $.extend(true, thisFrame, frameConfig.frameList[iFrame]);
 
         // Substitute any properties that can be replaced based on
         // the parameter set.

--- a/exp-player/addon/styles/components/exp-lookit-dialogue-page.scss
+++ b/exp-player/addon/styles/components/exp-lookit-dialogue-page.scss
@@ -144,4 +144,12 @@ $exp-lookit-dialogue-page-height: (100 - $exp-lookit-dialogue-page-top-margin - 
     font-size: x-large;
 }
 
+.exp-lookit-dialogue-page #waitForVideo, #experiment-player.player-fullscreen .exp-lookit-dialogue-page #waitForVideo {
+    font-size: x-large;
+    margin-top: 10%;
+    width: 400px;
+    margin-left: -200px;
+    left: 50%;
+    position: fixed;
+}
 


### PR DESCRIPTION
…d of substitutions could alter frame values in nested randomizers

<!-- 
For historical reasons, all changes intended for the International Situations Project consuming app must be targeted to 
the "ISP" branch" of this repo, rather than develop or master. Please make sure to point your PR (and submodule 
commits) at the correct branch.

This has been done to "freeze" ISP features for the shipped product, while allowing Lookit development to move forward.
-->

Refs: https://openscience.atlassian.net/browse/LEI-
Companion to: 

## Purpose
Quick fix to allow use of nested random-parameter-set frames with proper substitution - failure to make a deep copy of the commonFrameProperties, etc. was leading to the parameterSet substitutions altering outer-level frame parameters.

Could this be merged and pushed to staging-lookit (not prod; staging-experimenter okay but not necessary) ASAP if it looks okay? (We have a collaborator actively working on the structure of a study, with only a few days before going on leave, and she's using staging-lookit for testing.)

## Summary of changes


## Testing notes
https://staging-lookit.osf.io/participate/595e47603de08a0040031d53 works properly with these changes (two separate sets of images & audio), whereas before only the BACKGROUNDIMG changed between trials.
