### PR TITLE
timestamp change

### DIFF
--- a/exp-models/addon/serializers/session.js
+++ b/exp-models/addon/serializers/session.js
@@ -5,6 +5,12 @@ import JamDocumentSerializer from '../mixins/jam-document-serializer';
 
 export default DS.JSONAPISerializer.extend(JamSerializer, JamDocumentSerializer, {
     modelName: 'session',
+    attrs: {
+        createdOn: {serialize: false},
+        createdBy: {serialize: false},
+        modifiedOn: {serialize: true},
+        modifiedBy: {serialize: false}
+    },
     extractAttributes() {
         var attributes = this._super(...arguments);
         // Remove identifying information from the session model


### PR DESCRIPTION
<!-- 
For historical reasons, all changes intended for the International Situations Project consuming app must be targeted to 
the "ISP" branch" of this repo, rather than develop or master. Please make sure to point your PR (and submodule 
commits) at the correct branch.

This has been done to "freeze" ISP features for the shipped product, while allowing Lookit development to move forward.
-->

https://openscience.atlassian.net/browse/SVCS-382

## Purpose
Change a serializer to allow for a date completed field on exported csvs.


## Summary of changes
Changed serializer field to true on modifiedOn in exp-models/addon/serializers/session.js

## Testing notes

