### PR TITLE
cat3 dataloss fix. When you refresh the page, or leave the survey whi…

### DIFF
--- a/exp-player/addon/components/exp-card-sort/component.js
+++ b/exp-player/addon/components/exp-card-sort/component.js
@@ -448,6 +448,7 @@ export default ExpFrameBaseComponent.extend(ScrollToMixin, {
                 let name = bucket.name.split('.').pop();
                 Ember.set(bucket, 'cards', buckets[name]);
             }
+            this.set('cardSortResponse', Ember.copy(this.get('bucketsItems'), true));
         }
     }
 });


### PR DESCRIPTION
…le on cat9, the already saved cat3 gets overwritten. This is because the variable 'cardSortResponse' is not set as usual when coming back to the survey on the cat9 page. Adding this function call into loadData sets this variable up correctly, and then will be added when cat9 saves, and not completely get rid of cat3.

<!-- 
For historical reasons, all changes intended for the International Situations Project consuming app must be targeted to 
the "ISP" branch" of this repo, rather than develop or master. Please make sure to point your PR (and submodule 
commits) at the correct branch.

This has been done to "freeze" ISP features for the shipped product, while allowing Lookit development to move forward.
-->

Refs:https://openscience.atlassian.net/browse/SVCS-312
Companion to: 

## Purpose
Fix dataloss issue on cat9.

## Summary of changes
Added a function call in loadData (called when you come back to the cat9 page after leaving the survey) which properly sets up a variable which is needed to save cat3 data correctly. 
(If you never reload the page, the variable is already set up from completing cat3, and works correctly.)


## Testing notes
To replicate the issue:
* On old version, navigate to and complete the cat3 part of the survey. While on the cat9 page, refresh the page or quit the survey.
*Come back to the survey on the same account and complete cat9 and the radio button steps after.
*The cat9 data will overwrite the cat3 data, and new cat3 data will not be written.
*Navigate to experimenter and check the data for the account used. Cat3 data should be missing.

With fix:
*After doing the above steps, the cat3 data should be available on experimenter for the account.

