### PR TITLE
[SVCS-505]Color Cat9 text green on completion

### DIFF
--- a/exp-player/addon/components/exp-card-sort/template.hbs
+++ b/exp-player/addon/components/exp-card-sort/template.hbs
@@ -77,14 +77,14 @@
                     <div class="row">
                         {{#each group.categories as |category|}}
                             <div class="col-sm-4 small-bucket
-                                {{unless (eq category.cards.length category.max) 'text-danger validation-error'}}
+                                {{if (eq category.cards.length category.max) 'text-success' 'text-danger validation-error'}}
                                 ">
-                                <h5 class="bucket-label visible-xs {{if
+                                <h5 class="bucket-label text-center visible-xs {{if
                                     (eq category.name 'qsort.sections.2.categories.neutral') ''
                                     'bucket-label-margin'}}">
                                     {{t category.name}}
                                 </h5>
-                                <h5 class="text-center">
+                                <h5 class="text-center" style="font-size: 24px;">
                                     {{category.cards.length}}/{{category.max}}
                                 </h5>
                                 {{#draggable-object-target bucket=category.cards buckets=bucketsItems buckets2=buckets2Items


### PR DESCRIPTION
<!-- 
For historical reasons, all changes intended for the International Situations Project consuming app must be targeted to 
the "ISP" branch" of this repo, rather than develop or master. Please make sure to point your PR (and submodule 
commits) at the correct branch.

This has been done to "freeze" ISP features for the shipped product, while allowing Lookit development to move forward.
-->

Refs: https://openscience.atlassian.net/browse/SVCS-505

## Purpose
Change color of Cat9 text once a bucket has been completed

## Summary of changes
Styled template to do so

## Testing notes

