### PR TITLE
Physics study fixes

### DIFF
--- a/exp-player/addon/components/exp-exit-survey/component.js
+++ b/exp-player/addon/components/exp-exit-survey/component.js
@@ -92,6 +92,7 @@ export default ExpFrameBaseComponent.extend(Validations, FullScreen, {
     },
     today: new Date(),
     section1: true,
+    minVideosToCountSession: 6,
     showWithdrawalConfirmation: false,
     showValidation: false,
     actions: {
@@ -121,23 +122,44 @@ export default ExpFrameBaseComponent.extend(Validations, FullScreen, {
             this.send('next');
         }
     },
-    currentSessionsCompleted: Ember.computed('frameContext', function() {
-        var pastSessions = this.get('frameContext.pastSessions');
-        if (pastSessions) {
-            return pastSessions.get('length') || 1;
-        }
-        return 1;
-    }),
-    currentDaysSessionsCompleted: Ember.computed('frameContext', function() {
-        // Warning, this implementation may be inaccurate
-        // TODO, figure out what the client's expected behavior is here and resolve
-        // https://openscience.atlassian.net/browse/LEI-111
-        var pastSessionDates = this.get('frameContext.pastSessions').map((session) => moment(session.get('createdOn')));
-        var minDate = moment.min(pastSessionDates);
-        var maxDate = moment.max(pastSessionDates);
+    currentSessionStatus: Ember.computed('frameContext', function() {
+        // Count all sessions
+        //var pastSessions = this.get('frameContext.pastSessions');
+        //if (pastSessions) {
+        //    return pastSessions.get('length') || 1;
+        //}
 
-        return maxDate.diff(minDate, 'days') + 1;
+        // Count only sessions with at least minVideos pref-phys-videos frames
+        var expData = this.get('frameContext.pastSessions').map((session) => session.get('expData'));
+        var expDates = this.get('frameContext.pastSessions').map((session) => moment(session.get('createdOn')));
+        var nSessions = 0;
+        var sessionDates = [];
+        for (var iSess = 0; iSess < expData.length; iSess++) {
+            var keys = Object.keys(expData[iSess]);
+            var nVideos = 0;
+            for (let i = 0; i < keys.length; i++) {
+                var frameKeyName = keys[i];
+                if (frameKeyName.indexOf('pref-phys-videos') !== -1) {
+                    nVideos++;
+                }
+            }
+            if (nVideos >= this.get('minVideosToCountSession')) {
+                nSessions++;
+                sessionDates.push(expDates[iSess]);
+            }
+        }
+        var minDate = moment.min(sessionDates);
+        var maxDate = moment.max(sessionDates);
+        return [nSessions, maxDate.diff(minDate, 'days') + 1];
     }),
+    currentSessionsCompleted: Ember.computed('currentSessionStatus', function()    {
+        return this.get('currentSessionStatus')[0];
+    }),
+
+    currentDaysSessionsCompleted: Ember.computed('currentSessionStatus', function() {
+        return this.get('currentSessionStatus')[1];
+    }),
+
     progressValue: Ember.computed('currentSessionsCompleted', 'idealSessionsCompleted', function() {
         return Math.min(100, Math.ceil((this.get('currentSessionsCompleted') / this.get('idealSessionsCompleted')) * 100));
     }),

--- a/exp-player/addon/components/exp-exit-survey/template.hbs
+++ b/exp-player/addon/components/exp-exit-survey/template.hbs
@@ -137,8 +137,8 @@
         {{else}}
             <h4>{{title2}}</h4>
             <p>
-                Hooray! You have started <strong>{{currentSessionsCompleted}}</strong> session(s) in
-                <strong>{{currentDaysSessionsCompleted}}</strong> days.
+                Hooray! You have completed <strong>{{currentSessionsCompleted}}</strong> session(s) in
+                <strong>{{currentDaysSessionsCompleted}}</strong> days. (This includes all sessions where you completed at least the first {{minVideosToCountSession}} videos.)
             </p>
             <p>
                 We are asking parents to try to complete <strong>{{idealSessionsCompleted}}</strong> sessions within

--- a/exp-player/addon/randomizers/pref-phys.js
+++ b/exp-player/addon/randomizers/pref-phys.js
@@ -41,7 +41,7 @@ function getLastSession(pastSessions) {
 
 function getConditions(lastSession, frameId) {
     var startType, showStay, whichObjects;
-    var cb = counterbalancingLists();
+    const cb = counterbalancingLists();
     // The last session payload refers to the frame we want by number (#-frameName), but frames aren't numbered until the sequence
     //   has been resolved (eg until we expand pref-phys-videos into a series of video frames, we won't know how many
     //   frames there are or in what order)
@@ -58,15 +58,36 @@ function getConditions(lastSession, frameId) {
         }
     });
 
+    // If there are no conditions from previous sessions, just choose randomly!
     if (!lastFrameConditions) {
+        // Select counterbalancing conditions from the pseudorandom lists
+        // defined in counterbalancingLists. startType and showStay are
+        // indices into conceptOrderRotation and useFallRotation respectively.
+        // This is very clunky but preserved to ensure functionality is
+        // consistent.
+
+        // startType defines the order in which to rotate through concepts.
         startType = Math.floor(Math.random() * cb.conceptOrderRotation.length);
+        // showStay (historical name) says which support comparisons we should
+        //    use 'fall' rather than 'stay' videos for.
         showStay = Math.floor(Math.random() * cb.useFallRotation.length);
-        var whichObjectG = Math.floor(Math.random() * cb.objectRotations[0].length);
-        var whichObjectI = Math.floor(Math.random() * cb.objectRotations[1].length);
-        var whichObjectS = Math.floor(Math.random() * cb.objectRotations[2].length);
-        var whichObjectC = Math.floor(Math.random() * cb.objectRotations[3].length);
+
+        // the whichObjects[X] variables select comparison-object pairings to
+        // use for [concepts] - G = gravity, I = inertia, S = support,
+        // C = control. (E.g., pair 'lotion' with 'down-up ramp' comparison,
+        // 'cup' with 'down-up toss' comparison, etc.) Choose random indices
+        // into each respective pseudorandom list of possible pairings. (Note
+        // that the lists are not simply all permutations, because in a few
+        // cases we don't have particular objects for comparisons.)
+        const whichObjectG = Math.floor(Math.random() * cb.objectRotations[0].length);
+        const whichObjectI = Math.floor(Math.random() * cb.objectRotations[1].length);
+        const whichObjectS = Math.floor(Math.random() * cb.objectRotations[2].length);
+        const whichObjectC = Math.floor(Math.random() * cb.objectRotations[3].length);
+        // Store the indices into the comparison-object mapping lists as one
+        // array, gravity/inertia/support/control.
         whichObjects = [whichObjectG, whichObjectI, whichObjectS, whichObjectC];
-    } else {
+    } else { // Otherwise, increment each condition, which is actually an index
+    // into a predefined pseudorandom list of conditions to loop through.
 
         startType = lastFrameConditions.startType;
         startType++;
@@ -1271,7 +1292,7 @@ function assignVideos(startType, showStay, whichObjects) {
     var cb = counterbalancingLists();
 
     // Types of comparisons for each event type.
-    // Format [event, outcome1, outcome2]
+    // Format [event, outcome1, outcome2].
     var comparisonsGravity = [
         ['table', 'down', 'continue'],
         ['table', 'down', 'up'],

--- a/exp-player/addon/randomizers/pref-phys.js
+++ b/exp-player/addon/randomizers/pref-phys.js
@@ -61,10 +61,10 @@ function getConditions(lastSession, frameId) {
     if (!lastFrameConditions) {
         startType = Math.floor(Math.random() * cb.conceptOrderRotation.length);
         showStay = Math.floor(Math.random() * cb.useFallRotation.length);
-        var whichObjectG = Math.floor(Math.random() * 6);
-        var whichObjectI = Math.floor(Math.random() * 6);
-        var whichObjectS = Math.floor(Math.random() * 6);
-        var whichObjectC = Math.floor(Math.random() * 6);
+        var whichObjectG = Math.floor(Math.random() * cb.objectRotations[0].length);
+        var whichObjectI = Math.floor(Math.random() * cb.objectRotations[1].length);
+        var whichObjectS = Math.floor(Math.random() * cb.objectRotations[2].length);
+        var whichObjectC = Math.floor(Math.random() * cb.objectRotations[3].length);
         whichObjects = [whichObjectG, whichObjectI, whichObjectS, whichObjectC];
     } else {
 


### PR DESCRIPTION
<!-- 
For historical reasons, all changes intended for the International Situations Project consuming app must be targeted to 
the "ISP" branch" of this repo, rather than develop or master. Please make sure to point your PR (and submodule 
commits) at the correct branch.

This has been done to "freeze" ISP features for the shipped product, while allowing Lookit development to move forward.
-->

Display a more accurate session count to participants at the end of the physics study. Fix counterbalancing using one of the first 6 object mappings in the lists so it now chooses a random starting point.

